### PR TITLE
Fix -Wsign-compare when compiling with GCC

### DIFF
--- a/stout/event-loop.cc
+++ b/stout/event-loop.cc
@@ -31,7 +31,8 @@ void EventLoop::Clock::Pause() {
       },
       &timers);
 
-  CHECK_EQ(0, timers)
+  // NOTE: We use 0u to suppress -Wsign-compare (on GCC)
+  CHECK_EQ(0u, timers)
       << "pausing the clock with outstanding timers is unsupported";
 
   paused_.emplace(Now());


### PR DESCRIPTION
Compiling with GCC currently gives the following warning:
```
stout/event-loop.cc:34:3:   required from here
bazel-out/k8-dbg/bin/external/com_github_google_glog/_virtual_includes/glog/glog/logging.h:809:32: warning: comparison of integer expressions of different signedness: 'const int' and 'const long unsigned int' [-Wsign-compare]
```

This PR fixes said issue by changing `0` to `0u`.