### PR TITLE
Added `copts_` list + move `-std=c++17` in `BUILD`

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -2,10 +2,6 @@
 
 build --enable_platform_specific_config
 
-build:windows --compiler="clang-cl" --cxxopt="/std:c++17"
-
-build:macos --cxxopt=-std=c++17
-
-build:linux --cxxopt=-std=c++17
+build:windows --compiler="clang-cl" 
 
 build:clang --action_env=CC=clang

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,4 +1,5 @@
 load("@rules_cc//cc:defs.bzl", "cc_library")
+load("//bazel:copts.bzl", "copts")
 
 cc_library(
     name = "eventuals-base",
@@ -12,6 +13,7 @@ cc_library(
         "stout/closure.h",
         "stout/collect.h",
         "stout/compose.h",
+        "stout/concurrent.h",
         "stout/conditional.h",
         "stout/context.h",
         "stout/eventual.h",
@@ -44,8 +46,8 @@ cc_library(
         "stout/type-traits.h",
         "stout/undefined.h",
         "stout/until.h",
-        "stout/concurrent.h",
     ],
+    copts = copts(),
     visibility = ["//visibility:private"],
     deps = [
         "@com_github_google_glog//:glog",
@@ -64,6 +66,7 @@ cc_library(
         "stout/signal.h",
         "stout/timer.h",
     ],
+    copts = copts(),
     visibility = ["//visibility:private"],
     deps = [
         ":eventuals-base",
@@ -79,6 +82,7 @@ cc_library(
     hdrs = [
         "stout/http.h",
     ],
+    copts = copts(),
     defines = [
         # Windows build fails without this define.
         "GLOG_NO_ABBREVIATED_SEVERITIES",
@@ -99,6 +103,7 @@ cc_library(
 
 cc_library(
     name = "eventuals",
+    copts = copts(),
     visibility = ["//visibility:public"],
     deps = [
         ":eventuals-base",

--- a/bazel/copts.bzl
+++ b/bazel/copts.bzl
@@ -1,0 +1,27 @@
+"""Get compiler options for the specific OS."""
+
+# Common compiler options for macOS, Linux and Windows.
+copts_common = [
+    "-Werror",
+]
+
+# Get the final list of options composed with common options for the specific
+# OS.
+def copts():
+    return copts_common + select({
+        "@bazel_tools//src/conditions:windows": [
+            "\"/std:c++17\"",
+            "-Wno-error=microsoft-cast",
+            "-Wno-error=invalid-noreturn",
+            "-Wno-error=microsoft-include",
+        ],
+        "@bazel_tools//src/conditions:darwin": [
+            "-std=c++17",
+            # We do not want to treat `syscall` warning as an error.
+            # Future update of glog lib will fix this warning.
+            "-Wno-error=deprecated-declarations",
+        ],
+        "//conditions:default": [
+            "-std=c++17",
+        ],
+    })

--- a/test/BUILD.bazel
+++ b/test/BUILD.bazel
@@ -1,4 +1,5 @@
 load("@rules_cc//cc:defs.bzl", "cc_test")
+load("//bazel:copts.bzl", "copts")
 
 eventuals_base_sources = [
     "eventual.cc",
@@ -37,6 +38,7 @@ eventuals_http_sources = [
 cc_test(
     name = "eventuals",
     srcs = eventuals_base_sources + eventuals_events_sources + eventuals_http_sources,
+    copts = copts(),
     deps = [
         "//:eventuals",
         "@com_github_google_googletest//:gtest_main",


### PR DESCRIPTION
`copts_` list contains `-Werror` option in order to turn all warnings into the
errors. `-Wno-error=deprecated-declarations` option turns `syscall` warning
into a warning even if -Werror is specified.
Also I created an issue in the google/glog repo about `syscall` warning
[#717](https://github.com/google/glog/issues/717).