### PR TITLE
Refactor 'Task' and add new functionality

### DIFF
--- a/eventuals/terminal.h
+++ b/eventuals/terminal.h
@@ -63,9 +63,19 @@ struct _Terminal {
             << " but undefined";
       } else {
         if constexpr (IsUndefined<Context_>::value) {
-          fail_(std::forward<Args>(args)...);
+          if constexpr (sizeof...(args) > 0) {
+            fail_(std::forward<Args>(args)...);
+          } else {
+            fail_(std::runtime_error("ingress failed (without an error)"));
+          }
         } else {
-          fail_(context_, std::forward<Args>(args)...);
+          if constexpr (sizeof...(args) > 0) {
+            fail_(context_, std::forward<Args>(args)...);
+          } else {
+            fail_(
+                context_,
+                std::runtime_error("ingress failed (without an error)"));
+          }
         }
       }
     }

--- a/test/task.cc
+++ b/test/task.cc
@@ -1,13 +1,20 @@
 #include "eventuals/task.h"
 
+#include "eventuals/eventual.h"
 #include "eventuals/just.h"
+#include "eventuals/map.h"
+#include "eventuals/terminal.h"
 #include "eventuals/then.h"
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
+using eventuals::Eventual;
 using eventuals::Just;
+using eventuals::Map;
 using eventuals::Task;
 using eventuals::Then;
+
+using testing::MockFunction;
 
 TEST(TaskTest, Succeed) {
   auto e1 = []() -> Task<int> {
@@ -48,4 +55,136 @@ TEST(TaskTest, Succeed) {
   };
 
   EXPECT_EQ(42, *e4());
+}
+
+TEST(Task, Void) {
+  int x = 0;
+  auto e1 = [&x]() -> Task<void> {
+    return [&x]() {
+      return Then([&x]() {
+        x = 100;
+      });
+    };
+  };
+
+  *e1();
+
+  EXPECT_EQ(100, x);
+}
+
+TEST(Task, FailOnCallback) {
+  struct Functions {
+    MockFunction<void()> fail, stop, start;
+  };
+
+  Functions functions;
+
+  EXPECT_CALL(functions.fail, Call())
+      .Times(1);
+
+  EXPECT_CALL(functions.stop, Call())
+      .Times(0);
+
+  EXPECT_CALL(functions.start, Call())
+      .Times(0);
+
+  auto e = [&]() -> Task<int> {
+    return [&]() {
+      return Eventual<int>()
+                 .start([](auto& k) {
+                   k.Fail("error");
+                 })
+                 .fail([&](auto& k, auto&& error) {
+                   functions.fail.Call();
+                   k.Fail("error");
+                 })
+          | Then([](int) { return 1; })
+          | Eventual<int>()
+                .start([&](auto& k, auto&& value) {
+                  functions.start.Call();
+                })
+                .stop([&](auto&) {
+                  functions.stop.Call();
+                })
+                .fail([&](auto& k, auto&& error) {
+                  functions.fail.Call();
+                  k.Fail(error);
+                });
+    };
+  };
+
+  EXPECT_THROW(*e(), std::exception_ptr);
+}
+
+TEST(Task, Fail) {
+  MockFunction<void()> fail;
+
+  EXPECT_CALL(fail, Call())
+      .Times(1);
+
+  auto e = [&]() -> Task<int> {
+    return [&]() {
+      return Eventual<int>()
+                 .start([](auto& k) {
+                   k.Fail("error");
+                 })
+                 .fail([&](auto& k, auto&& error) {
+                   fail.Call();
+                   k.Fail("error");
+                 })
+          | Then([](int x) { return x + 1; });
+    };
+  };
+
+  auto [future, k] = Terminate(e());
+  k.Fail("error");
+
+  EXPECT_THROW(future.get(), std::exception_ptr);
+}
+
+TEST(Task, StopOnCallback) {
+  MockFunction<void()> stop;
+
+  EXPECT_CALL(stop, Call())
+      .Times(0);
+
+  auto e = [&]() -> Task<int> {
+    return [&]() {
+      return Eventual<int>()
+          .start([](auto& k) {
+            k.Stop();
+          })
+          .stop([&](auto& k) {
+            stop.Call();
+            k.Stop();
+          });
+    };
+  };
+
+  EXPECT_THROW(*e(), eventuals::StoppedException);
+}
+
+TEST(Task, Stop) {
+  MockFunction<void()> stop;
+
+  EXPECT_CALL(stop, Call())
+      .Times(1);
+
+  auto e = [&]() -> Task<int> {
+    return [&]() {
+      return Eventual<int>()
+          .start([](auto& k) {
+            k.Stop();
+          })
+          .stop([&](auto& k) {
+            stop.Call();
+            k.Stop();
+          });
+    };
+  };
+
+  auto [future, k] = Terminate(e());
+  k.Stop();
+
+  EXPECT_THROW(future.get(), eventuals::StoppedException);
 }


### PR DESCRIPTION
Rewrite Task eventual with `Composable` and `Continuation`.

Add support of using `Task<void>...` that returns nothing.

Add propagation for `Fail` and `Stop` callbacks