### PR TITLE
Introduce `DoAll()` implementation

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -16,6 +16,7 @@ cc_library(
         "eventuals/concurrent.h",
         "eventuals/conditional.h",
         "eventuals/context.h",
+        "eventuals/do-all.h",
         "eventuals/eventual.h",
         "eventuals/filter.h",
         "eventuals/head.h",

--- a/eventuals/do-all.h
+++ b/eventuals/do-all.h
@@ -1,0 +1,166 @@
+#include <atomic>
+#include <tuple>
+#include <variant>
+
+#include "eventuals/compose.h"
+#include "eventuals/terminal.h"
+
+namespace eventuals {
+namespace detail {
+
+struct _DoAll {
+  template <typename K_, typename... Eventuals_>
+  struct Adaptor {
+    Adaptor(K_& k)
+      : k_(k) {}
+    Adaptor(Adaptor&& that)
+      : k_(that.k_) {
+      CHECK(that.counter_.load() == sizeof...(Eventuals_))
+          << "moving after starting is illegal";
+    }
+
+    K_& k_;
+
+    std::tuple<
+        std::variant<
+            std::conditional_t<
+                std::is_void_v<typename Eventuals_::template ValueFrom<void>>,
+                std::monostate,
+                typename Eventuals_::template ValueFrom<void>>,
+            std::exception_ptr>...>
+        values_;
+
+    std::atomic<size_t> counter_ = sizeof...(Eventuals_);
+
+    template <size_t index, typename Eventual>
+    auto BuildEventual(Eventual eventual) {
+      return Build(
+          std::move(eventual)
+          | Terminal()
+                .start([this](auto&&... value) {
+                  if constexpr (sizeof...(value) != 0) {
+                    std::get<index>(values_)
+                        .template emplace<std::decay_t<decltype(value)>...>(
+                            std::forward<decltype(value)>(value)...);
+                  } else {
+                    // Assume it's void, std::monostate will be the default.
+                  }
+                  if (counter_.fetch_sub(1) == 1) {
+                    // You're the last eventual so call the continuation.
+                    k_.Start(std::move(values_));
+                  }
+                })
+                .fail([this](auto&&... errors) {
+                  std::get<index>(values_)
+                      .template emplace<std::exception_ptr>(
+                          std::make_exception_ptr(
+                              std::forward<decltype(errors)>(errors)...));
+                  if (counter_.fetch_sub(1) == 1) {
+                    // You're the last eventual so call the continuation.
+                    k_.Start(std::move(values_));
+                  }
+                })
+                .stop([this]() {
+                  std::get<index>(values_)
+                      .template emplace<std::exception_ptr>(
+                          std::make_exception_ptr(
+                              StoppedException()));
+                  if (counter_.fetch_sub(1) == 1) {
+                    // You're the last eventual so call the continuation.
+                    k_.Start(std::move(values_));
+                  }
+                }));
+    }
+
+    template <size_t... index>
+    auto BuildAll(
+        std::tuple<Eventuals_...>&& eventuals,
+        std::index_sequence<index...>) {
+      return std::make_tuple(
+          BuildEventual<index>(std::move(std::get<index>(eventuals)))...);
+    }
+  };
+
+  template <typename K_, typename... Eventuals_>
+  struct Continuation {
+    template <typename... Args>
+    void Start(Args&&...) {
+      adaptor_.emplace(k_);
+
+      ks_.emplace(adaptor_->BuildAll(
+          std::move(eventuals_),
+          std::make_index_sequence<sizeof...(Eventuals_)>{}));
+
+      std::apply(
+          [this](auto&... k) {
+            if (interrupt_ != nullptr) {
+              (k.Register(*interrupt_), ...);
+            }
+            (k.Start(), ...);
+          },
+          ks_.value());
+    }
+
+    template <typename... Args>
+    void Fail(Args&&... args) {
+      // TODO: consider propagating through each eventual?
+      k_.Fail(std::forward<Args>(args)...);
+    }
+
+    void Stop() {
+      // TODO: consider propagating through each eventual?
+      k_.Stop();
+    }
+
+    void Register(Interrupt& interrupt) {
+      interrupt_ = &interrupt;
+      k_.Register(interrupt);
+    }
+
+    K_ k_;
+    std::tuple<Eventuals_...> eventuals_;
+
+    std::optional<Adaptor<K_, Eventuals_...>> adaptor_;
+
+    std::optional<
+        decltype(adaptor_->BuildAll(
+            std::move(eventuals_),
+            std::make_index_sequence<sizeof...(Eventuals_)>{}))>
+        ks_;
+
+    Interrupt* interrupt_ = nullptr;
+  };
+
+  template <typename... Eventuals_>
+  struct Composable {
+    template <typename Arg>
+    using ValueFrom =
+        std::tuple<
+            std::variant<
+                std::conditional_t<
+                    std::is_void_v<
+                        typename Eventuals_::template ValueFrom<void>>,
+                    std::monostate,
+                    typename Eventuals_::template ValueFrom<void>>,
+                std::exception_ptr>...>;
+
+    template <typename Arg, typename K>
+    auto k(K k) && {
+      return Continuation<K, Eventuals_...>{
+          std::move(k),
+          std::move(eventuals_)};
+    }
+
+    std::tuple<Eventuals_...> eventuals_;
+  };
+};
+
+} // namespace detail
+
+template <typename Eventual, typename... Eventuals>
+auto DoAll(Eventual eventual, Eventuals... eventuals) {
+  return detail::_DoAll::Composable<Eventual, Eventuals...>{
+      std::make_tuple(std::move(eventual), std::move(eventuals)...)};
+}
+
+} // namespace eventuals

--- a/test/BUILD.bazel
+++ b/test/BUILD.bazel
@@ -21,6 +21,7 @@ eventuals_base_sources = [
     "let.cc",
     "stream-for-each.cc",
     "concurrent.cc",
+    "do-all.cc",
 ]
 
 eventuals_events_sources = [

--- a/test/do-all.cc
+++ b/test/do-all.cc
@@ -1,0 +1,133 @@
+#include "eventuals/do-all.h"
+
+#include "eventuals/eventual.h"
+#include "eventuals/terminal.h"
+#include "eventuals/then.h"
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+
+using eventuals::Build;
+using eventuals::DoAll;
+using eventuals::Eventual;
+using eventuals::Interrupt;
+using eventuals::Terminal;
+using eventuals::Terminate;
+using eventuals::Then;
+
+using testing::MockFunction;
+
+TEST(DoAllTest, Succeed) {
+  auto e = []() {
+    return DoAll(
+        Eventual<int>([](auto& k) { k.Start(42); }),
+        Eventual<std::string>([](auto& k) { k.Start(std::string("hello")); }),
+        Eventual<void>([](auto& k) { k.Start(); }));
+  };
+
+  auto result = *e();
+
+  using T = std::decay_t<decltype(result)>;
+  EXPECT_EQ(
+      std::tuple_size_v<T>,
+      3);
+  EXPECT_EQ(
+      std::get<0>(result).valueless_by_exception(),
+      false);
+  EXPECT_EQ(
+      std::get<1>(result).valueless_by_exception(),
+      false);
+  EXPECT_EQ(
+      std::get<2>(result).valueless_by_exception(),
+      false);
+
+  using T1 = decltype(std::get<0>(std::get<0>(result)));
+  using T2 = decltype(std::get<0>(std::get<1>(result)));
+  using T3 = decltype(std::get<0>(std::get<2>(result)));
+
+  EXPECT_EQ((std::is_same_v<T1, int&>), true);
+  EXPECT_EQ((std::is_same_v<T2, std::string&>), true);
+  EXPECT_EQ((std::is_same_v<T3, std::monostate&>), true);
+  EXPECT_EQ(
+      (std::make_tuple(
+          std::variant<int, std::exception_ptr>(42),
+          std::variant<std::string, std::exception_ptr>("hello"),
+          std::variant<std::monostate, std::exception_ptr>())),
+      result);
+}
+
+
+TEST(DoAllTest, Fail) {
+  auto e = []() {
+    return DoAll(Eventual<void>([](auto& k) { k.Fail("error"); }));
+  };
+
+  auto result = *e();
+
+  using T1 = decltype(result);
+  using T2 = std::tuple<std::variant<
+      std::monostate,
+      std::exception_ptr>>;
+
+  EXPECT_EQ(
+      (std::tuple_size_v<std::decay_t<decltype(result)>>),
+      1);
+  EXPECT_EQ((std::is_same_v<T1, T2>), true);
+  EXPECT_EQ(
+      (std::holds_alternative<std::exception_ptr>(
+          std::get<0>(result))),
+      true);
+}
+
+
+TEST(DoAllTest, Interrupt) {
+  MockFunction<void()> start, fail;
+
+  EXPECT_CALL(start, Call())
+      .Times(1);
+
+  EXPECT_CALL(fail, Call())
+      .Times(0);
+
+  auto e = [&start, &fail]() {
+    return DoAll(Eventual<void>()
+                     .start([&start](auto& k) {
+                       start.Call();
+                     })
+                     .fail([&fail](auto& k) {
+                       fail.Call();
+                     })
+                     .interrupt([](auto& k) {
+                       k.Stop();
+                     }));
+  };
+
+  auto [future, k] = Terminate(e());
+
+  Interrupt interrupt;
+
+  k.Register(interrupt);
+
+  k.Start();
+
+  EXPECT_EQ(
+      std::future_status::timeout,
+      future.wait_for(std::chrono::seconds(0)));
+
+  interrupt.Trigger();
+
+  auto result = future.get();
+
+  using T1 = decltype(result);
+  using T2 = std::tuple<std::variant<
+      std::monostate,
+      std::exception_ptr>>;
+
+  EXPECT_EQ(
+      (std::tuple_size_v<std::decay_t<decltype(result)>>),
+      1);
+  EXPECT_EQ((std::is_same_v<T1, T2>), true);
+  EXPECT_EQ(
+      (std::holds_alternative<std::exception_ptr>(
+          std::get<0>(result))),
+      true);
+}


### PR DESCRIPTION
Basically `DoAll()` takes a variadic list of eventuals, terminate them, store
them in a `std::tuple`, call `Start()` on all them, wait for them all to be
done, and then continue with a tuple of results from each of the eventuals
passed in. Each result may be either a result from eventual or `std::exception`.