### PR TITLE
Update the chosen commit of 3rdparty/bazel-rules-jemalloc

### DIFF
--- a/3rdparty/bazel-rules-jemalloc/repos.bzl
+++ b/3rdparty/bazel-rules-jemalloc/repos.bzl
@@ -28,7 +28,7 @@ def repos(external = True, repo_mapping = {}):
             git_repository,
             name = "com_github_3rdparty_bazel_rules_jemalloc",
             remote = "https://github.com/3rdparty/bazel-rules-jemalloc",
-            commit = "29a706360a8ce9f425599d862a5d9328e2ae4d14",
-            shallow_since = "1634890910 +0300",
+            commit = "ccfd8d5c6e9681c772145cc5b7e51283cfd435b0",
+            shallow_since = "1634911695 +0200",
             repo_mapping = repo_mapping,
         )


### PR DESCRIPTION
… to use a new version that builds on GitHub Actions' Mac machines.