### PR TITLE
Refactor interrupt semantics for 'Eventual', 'Loop', and 'Stream'

### DIFF
--- a/eventuals/eventual.h
+++ b/eventuals/eventual.h
@@ -53,22 +53,31 @@ struct _Eventual {
           !IsUndefined<Start_>::value,
           "Undefined 'start' (and no default)");
 
-      auto interrupted = [this]() mutable {
-        if (handler_) {
-          return !handler_->Install();
-        } else {
-          return false;
-        }
-      }();
-
-      if (interrupted) {
-        assert(handler_);
+      // NOTE: we check if an interrupt has been triggered _before_ we
+      // call start but don't install the interrupt handler until
+      // _after_ calling start to simplify start handlers that might
+      // want to do some set up without worrying about interrupt races
+      // before they return (they will still have the race after they
+      // return with an interrupt and what ever they were waiting for,
+      // but at least they won't have any race while setting up what
+      // ever they want to wait for).
+      //
+      // TODO(benh): consider calling 'start_' with the interrupt to
+      // let them decide what they want to do rather than always
+      // skipping 'start_' if an interrupt has been triggered.
+      if (handler_ && handler_->interrupt().Triggered()) {
         handler_->Invoke();
       } else {
         if constexpr (IsUndefined<Context_>::value) {
           start_(k_(), std::forward<Args>(args)...);
         } else {
           start_(context_, k_(), std::forward<Args>(args)...);
+        }
+
+        if (handler_) {
+          if (!handler_->Install()) {
+            handler_->Invoke();
+          }
         }
       }
     }

--- a/eventuals/interrupt.h
+++ b/eventuals/interrupt.h
@@ -28,6 +28,10 @@ class Interrupt {
       CHECK(that.next_ == nullptr);
     }
 
+    Interrupt& interrupt() {
+      return *CHECK_NOTNULL(interrupt_);
+    }
+
     bool Install() {
       CHECK_NOTNULL(interrupt_);
       return interrupt_->Install(this);
@@ -76,6 +80,11 @@ class Interrupt {
         handler = next;
       }
     }
+  }
+
+  bool Triggered() {
+    // NOTE: nullptr signifies that the interrupt has been triggered.
+    return head_.load() == nullptr;
   }
 
   // To simplify the implementation we signify a triggered interrupt


### PR DESCRIPTION
To simplify writing the "start" callback for 'Eventual', 'Loop', and
'Stream' we only install the interrupt handler _after_ invoking the
callback. Programmers still need to worry about the race of an
interrupt occurring at the same time that what ever they are waiting
for occurs, but at least they don't need to worry about any races
while they are doing any set up for what ever it is that they are
waiting for.

Note that we also removed interrupt handling from 'Terminal' because
if we've gotten to the 'Terminal' then we won't be waiting so there's
no reason to have an interrupt handler!