### PR TITLE
Introduce `Transformer`

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -46,6 +46,7 @@ cc_library(
         "eventuals/task.h",
         "eventuals/terminal.h",
         "eventuals/then.h",
+        "eventuals/transformer.h",
         "eventuals/type-traits.h",
         "eventuals/undefined.h",
         "eventuals/unpack.h",

--- a/eventuals/transformer.h
+++ b/eventuals/transformer.h
@@ -1,0 +1,379 @@
+#pragma once
+
+#include <memory>
+#include <optional>
+
+#include "eventuals/callback.h"
+#include "eventuals/stream.h"
+
+////////////////////////////////////////////////////////////////////////
+
+namespace eventuals {
+
+////////////////////////////////////////////////////////////////////////
+
+namespace detail {
+
+////////////////////////////////////////////////////////////////////////
+
+template <typename E_, typename From_, typename To_>
+struct HeapTransformer {
+  struct Adaptor {
+    Adaptor(
+        Callback<TypeErasedStream&>* begin,
+        Callback<std::exception_ptr>* fail,
+        Callback<>* stop,
+        Callback<To_>* body,
+        Callback<>* ended)
+      : begin_(begin),
+        fail_(fail),
+        stop_(stop),
+        body_(body),
+        ended_(ended) {}
+
+    // All functions are called as Continuation after produced Stream.
+    void Begin(TypeErasedStream& stream) {
+      (*begin_)(stream);
+    }
+
+    template <typename... Args>
+    void Body(Args&&... args) {
+      (*body_)(std::forward<decltype(args)>(args)...);
+    }
+
+    template <typename... Args>
+    void Fail(Args&&... args) {
+      (*fail_)(
+          std::make_exception_ptr(
+              std::forward<decltype(args)>(args)...));
+    }
+
+    // NOTE: overload so we don't create nested std::exception_ptr.
+    void Fail(std::exception_ptr exception) {
+      (*fail_)(std::move(exception));
+    }
+
+    void Stop() {
+      (*stop_)();
+    }
+
+    void Ended() {
+      (*ended_)();
+    }
+
+    // Already registered in 'adapted_'
+    void Register(Interrupt&) {}
+
+    Callback<TypeErasedStream&>* begin_;
+    Callback<std::exception_ptr>* fail_;
+    Callback<>* stop_;
+    Callback<To_>* body_;
+    Callback<>* ended_;
+  };
+
+  HeapTransformer(E_ e)
+    : adapted_(
+        std::move(e).template k<From_>(
+            Adaptor{&begin_, &fail_, &stop_, &body_, &ended_})) {}
+
+  void Body(
+      From_&& arg,
+      Interrupt& interrupt,
+      Callback<TypeErasedStream&>&& begin,
+      Callback<std::exception_ptr>&& fail,
+      Callback<>&& stop,
+      Callback<To_>&& body,
+      Callback<>&& ended) {
+    begin_ = std::move(begin);
+    fail_ = std::move(fail);
+    stop_ = std::move(stop);
+    body_ = std::move(body);
+    ended_ = std::move(ended);
+
+    adapted_.Register(interrupt);
+
+    adapted_.Body(std::move(arg));
+  }
+
+  void Fail(
+      Interrupt& interrupt,
+      std::exception_ptr&& exception,
+      Callback<TypeErasedStream&>&& begin,
+      Callback<std::exception_ptr>&& fail,
+      Callback<>&& stop,
+      Callback<To_>&& body,
+      Callback<>&& ended) {
+    begin_ = std::move(begin);
+    fail_ = std::move(fail);
+    stop_ = std::move(stop);
+    body_ = std::move(body);
+    ended_ = std::move(ended);
+
+    adapted_.Register(interrupt);
+
+    adapted_.Fail(std::move(exception));
+  }
+
+  void Stop(
+      Interrupt& interrupt,
+      Callback<TypeErasedStream&>&& begin,
+      Callback<std::exception_ptr>&& fail,
+      Callback<>&& stop,
+      Callback<To_>&& body,
+      Callback<>&& ended) {
+    begin_ = std::move(begin);
+    fail_ = std::move(fail);
+    stop_ = std::move(stop);
+    body_ = std::move(body);
+    ended_ = std::move(ended);
+
+    adapted_.Register(interrupt);
+
+    adapted_.Stop();
+  }
+
+  Callback<TypeErasedStream&> begin_;
+  Callback<std::exception_ptr> fail_;
+  Callback<> stop_;
+  Callback<To_> body_;
+  Callback<> ended_;
+
+  using Adapted_ = decltype(std::declval<E_>().template k<From_>(
+      std::declval<Adaptor>()));
+
+  Adapted_ adapted_;
+};
+
+////////////////////////////////////////////////////////////////////////
+
+struct _Transformer {
+  enum class Action {
+    Body = 0,
+    Fail = 1,
+    Stop = 2,
+  };
+
+  template <typename K_, typename From_, typename To_>
+  struct Continuation {
+    void Begin(TypeErasedStream& stream) {
+      k_.Begin(stream);
+    }
+
+    template <typename... Args>
+    void Fail(Args&&... args) {
+      static_assert(
+          sizeof...(args) > 0,
+          "Transformer expects Fail() to be called with an argument");
+      auto exception = std::make_exception_ptr(
+          std::forward<decltype(args)>(args)...);
+
+      Dispatch(Action::Fail, std::nullopt, std::move(exception));
+    }
+
+    void Stop() {
+      Dispatch(Action::Stop);
+    }
+
+    template <typename... From>
+    void Body(From&&... from) {
+      Dispatch(Action::Body, std::forward<From>(from)...);
+    }
+
+    void Ended() {
+      k_.Ended();
+    }
+
+    void Register(Interrupt& interrupt) {
+      interrupt_ = &interrupt;
+      k_.Register(interrupt);
+    }
+
+    void Dispatch(
+        Action action,
+        std::optional<From_>&& from = std::nullopt,
+        std::optional<std::exception_ptr>&& exception = std::nullopt) {
+      dispatch_(
+          action,
+          std::move(exception),
+          std::move(from),
+          e_,
+          *interrupt_,
+          [this](TypeErasedStream& stream) {
+            k_.Begin(stream);
+          },
+          [this](To_ arg) {
+            k_.Body(std::move(arg));
+          },
+          [this](std::exception_ptr e) {
+            k_.Fail(std::move(e));
+          },
+          [this]() {
+            k_.Stop();
+          },
+          [this]() {
+            k_.Ended();
+          });
+    }
+
+    K_ k_;
+    Callback<
+        Action,
+        std::optional<std::exception_ptr>&&,
+        std::optional<From_>&&,
+        std::unique_ptr<void, Callback<void*>>&,
+        Interrupt&,
+        Callback<TypeErasedStream&>&&,
+        Callback<To_>&&,
+        Callback<std::exception_ptr>&&,
+        Callback<>&&,
+        Callback<>&&>
+        dispatch_;
+
+    std::unique_ptr<void, Callback<void*>> e_;
+    Interrupt* interrupt_ = nullptr;
+  };
+
+  template <typename From_, typename To_>
+  struct Composable {
+    template <typename>
+    using ValueFrom = To_;
+
+    template <typename F>
+    Composable(F f) {
+      static_assert(
+          std::is_invocable_v<F>,
+          "'Transformer' expects a callable that "
+          "takes no arguments");
+
+      static_assert(
+          sizeof(f) <= sizeof(void*),
+          "'Transformer' expects a callable that "
+          "can be captured in a 'Callback'");
+
+      using E = decltype(f());
+
+      using Value = typename E::template ValueFrom<From_>;
+
+      static_assert(
+          std::is_convertible_v<Value, To_>,
+          "eventual result type can not be converted "
+          "into type of 'Transformer'");
+
+      dispatch_ = [f = std::move(f)](
+                      Action action,
+                      std::optional<std::exception_ptr>&& exception,
+                      std::optional<From_>&& from,
+                      std::unique_ptr<void, Callback<void*>>& e_,
+                      Interrupt& interrupt,
+                      Callback<TypeErasedStream&>&& begin,
+                      Callback<To_>&& body,
+                      Callback<std::exception_ptr>&& fail,
+                      Callback<>&& stop,
+                      Callback<>&& ended) {
+        if (!e_) {
+          e_ = std::unique_ptr<void, Callback<void*>>(
+              new HeapTransformer<E, From_, To_>(f()),
+              [](void* e) {
+                delete static_cast<detail::HeapTransformer<E, From_, To_>*>(e);
+              });
+        }
+
+        auto* e = static_cast<HeapTransformer<E, From_, To_>*>(e_.get());
+
+        switch (action) {
+          case Action::Body:
+            CHECK(from);
+            e->Body(
+                std::move(from.value()),
+                interrupt,
+                std::move(begin),
+                std::move(fail),
+                std::move(stop),
+                std::move(body),
+                std::move(ended));
+            break;
+          case Action::Fail:
+            CHECK(exception);
+            e->Fail(
+                interrupt,
+                std::move(exception.value()),
+                std::move(begin),
+                std::move(fail),
+                std::move(stop),
+                std::move(body),
+                std::move(ended));
+            break;
+          case Action::Stop:
+            e->Stop(
+                interrupt,
+                std::move(begin),
+                std::move(fail),
+                std::move(stop),
+                std::move(body),
+                std::move(ended));
+            break;
+          default:
+            LOG(FATAL) << "unreachable";
+        }
+      };
+    }
+
+    template <typename Arg, typename K>
+    auto k(K k) && {
+      return Continuation<K, From_, To_>{
+          std::move(k),
+          std::move(dispatch_)};
+    }
+
+    Callback<
+        Action,
+        std::optional<std::exception_ptr>&&,
+        std::optional<From_>&&,
+        std::unique_ptr<void, Callback<void*>>&,
+        Interrupt&,
+        Callback<TypeErasedStream&>&&,
+        Callback<To_>&&,
+        Callback<std::exception_ptr>&&,
+        Callback<>&&,
+        Callback<>&&>
+        dispatch_;
+  };
+};
+
+////////////////////////////////////////////////////////////////////////
+
+} // namespace detail
+
+////////////////////////////////////////////////////////////////////////
+
+template <typename From_, typename To_>
+class Transformer {
+ public:
+  template <typename>
+  using ValueFrom = To_;
+
+  template <typename F>
+  Transformer(F f)
+    : e_(std::move(f)) {}
+
+  template <typename Arg, typename K>
+  auto k(K k) && {
+    return std::move(e_).template k<Arg>(std::move(k));
+  }
+
+  // NOTE: should only be used in tests!
+  auto operator*() && {
+    auto [future, k] = Terminate(std::move(e_));
+    k.Start();
+    return future.get();
+  }
+
+ private:
+  detail::_Transformer::Composable<From_, To_> e_;
+};
+
+////////////////////////////////////////////////////////////////////////
+
+} // namespace eventuals
+
+////////////////////////////////////////////////////////////////////////

--- a/test/BUILD.bazel
+++ b/test/BUILD.bazel
@@ -26,6 +26,7 @@ eventuals_base_sources = [
     "foreach.cc",
     "expected.cc",
     "unpack.cc",
+    "transformer.cc",
 ]
 
 eventuals_events_sources = [

--- a/test/transformer.cc
+++ b/test/transformer.cc
@@ -1,0 +1,228 @@
+#include "eventuals/transformer.h"
+
+#include <string>
+
+#include "eventuals/collect.h"
+#include "eventuals/eventual.h"
+#include "eventuals/interrupt.h"
+#include "eventuals/iterate.h"
+#include "eventuals/let.h"
+#include "eventuals/map.h"
+#include "eventuals/stream.h"
+#include "eventuals/terminal.h"
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+
+using eventuals::Collect;
+using eventuals::Eventual;
+using eventuals::Interrupt;
+using eventuals::Iterate;
+using eventuals::Let;
+using eventuals::Map;
+using eventuals::Stream;
+using eventuals::Transformer;
+
+using testing::ElementsAre;
+using testing::MockFunction;
+
+TEST(Transformer, Succeed) {
+  auto transformer = []() {
+    return Transformer<int, std::string>(
+        []() {
+          return Map([](int&& x) {
+            return std::to_string(x);
+          });
+        });
+  };
+
+  auto e = [&]() {
+    return Iterate({100})
+        | transformer()
+        | Map([](std::string s) {
+             return s;
+           })
+        | Collect<std::vector<std::string>>();
+  };
+
+  EXPECT_THAT(*e(), ElementsAre("100"));
+}
+
+TEST(Transformer, Stop) {
+  MockFunction<void()> map_start;
+
+  EXPECT_CALL(map_start, Call())
+      .Times(0);
+
+  auto transformer = [&]() {
+    return Transformer<int, std::string>(
+        [&]() {
+          return Map([&](int&& x) {
+            map_start.Call();
+            return std::to_string(x);
+          });
+        });
+  };
+
+  auto e = [&]() {
+    return Stream<int>()
+               .next([](auto& k) {
+                 k.Stop();
+               })
+        | transformer()
+        | Map([&](std::string s) {
+             map_start.Call();
+             return s;
+           })
+        | Collect<std::vector<std::string>>();
+  };
+
+  EXPECT_THROW(*e(), eventuals::StoppedException);
+}
+
+TEST(Transformer, Fail) {
+  MockFunction<void()> map_start;
+
+  EXPECT_CALL(map_start, Call())
+      .Times(0);
+
+  auto transformer = [&]() {
+    return Transformer<int, std::string>(
+        [&]() {
+          return Map([&](int&& x) {
+            map_start.Call();
+            return std::to_string(x);
+          });
+        });
+  };
+
+  auto e = [&]() {
+    return Stream<int>()
+               .next([](auto& k) {
+                 k.Fail("error");
+               })
+        | transformer()
+        | Map([&](std::string s) {
+             map_start.Call();
+             return s;
+           })
+        | Collect<std::vector<std::string>>();
+  };
+
+  EXPECT_THROW(*e(), std::exception_ptr);
+}
+
+TEST(Transformer, Interrupt) {
+  MockFunction<void()> map_start, next, done;
+
+  EXPECT_CALL(map_start, Call())
+      .Times(0);
+
+  EXPECT_CALL(next, Call())
+      .Times(1);
+
+  EXPECT_CALL(done, Call())
+      .Times(0);
+
+  auto transformer = [&]() {
+    return Transformer<int, std::string>(
+        [&]() {
+          return Map([&](int&& x) {
+            map_start.Call();
+            return std::to_string(x);
+          });
+        });
+  };
+
+  auto e = [&]() {
+    return Stream<int>()
+               .interruptible()
+               .begin([](auto& k, Interrupt::Handler& handler) {
+                 handler.Install([&]() {
+                   k.Stop();
+                 });
+                 k.Begin();
+               })
+               .next([&](auto&) {
+                 next.Call();
+               })
+               .done([&](auto&) {
+                 done.Call();
+               })
+        | transformer()
+        | Map([&](std::string s) {
+             map_start.Call();
+             return s;
+           })
+        | Collect<std::vector<std::string>>();
+  };
+
+  Interrupt interrupt;
+
+  auto [future, k] = Terminate(e());
+
+  k.Register(interrupt);
+
+  k.Start();
+
+  interrupt.Trigger();
+
+  EXPECT_THROW(future.get(), eventuals::StoppedException);
+}
+
+TEST(Transformer, PropagateStop) {
+  MockFunction<void()> map_start;
+
+  EXPECT_CALL(map_start, Call())
+      .Times(0);
+
+  auto transformer = []() {
+    return Transformer<int, std::string>([]() {
+      return Map(Let([](auto& i) {
+        return Eventual<std::string>([](auto& k) {
+          k.Stop();
+        });
+      }));
+    });
+  };
+
+  auto e = [&]() {
+    return Iterate({100})
+        | transformer()
+        | Map([&](std::string s) {
+             map_start.Call();
+             return s;
+           })
+        | Collect<std::vector<std::string>>();
+  };
+
+  EXPECT_THROW(*e(), eventuals::StoppedException);
+}
+
+TEST(Transformer, PropagateFail) {
+  MockFunction<void()> map_start;
+
+  EXPECT_CALL(map_start, Call())
+      .Times(0);
+
+  auto transformer = []() {
+    return Transformer<int, std::string>([]() {
+      return Map(Let([](auto& i) {
+        return Eventual<std::string>([](auto& k) {
+          k.Fail("error");
+        });
+      }));
+    });
+  };
+
+  auto e = [&]() {
+    return Iterate({100})
+        | transformer()
+        | Map([&](std::string s) {
+             map_start.Call();
+             return s;
+           })
+        | Collect<std::vector<std::string>>();
+  };
+
+  EXPECT_THROW(*e(), std::exception_ptr);
+}


### PR DESCRIPTION
`Transformer` is a type-erased that basically allows transforming return types of eventual during the work.
 
Pseudo-code:
```
Stream(<type From>)
  | Transformer<<type From>, <type To>>("transformer labmda")
  | Other stuff that takes <type To>
```