### PR TITLE
Introduce 'WaitForSignal()'

### DIFF
--- a/eventuals/signal.h
+++ b/eventuals/signal.h
@@ -1,6 +1,11 @@
 #pragma once
 
+#include "eventuals/concurrent.h"
 #include "eventuals/event-loop.h"
+#include "eventuals/head.h"
+#include "eventuals/iterate.h"
+#include "eventuals/just.h"
+#include "eventuals/map.h"
 
 ////////////////////////////////////////////////////////////////////////
 
@@ -16,6 +21,30 @@ inline auto Signal(EventLoop& loop, const int& signum) {
 
 inline auto Signal(const int& signum) {
   return EventLoop::Default().Signal(signum);
+}
+
+////////////////////////////////////////////////////////////////////////
+
+// Eventual that waits for one of the specified signals to be raised
+// and then propagates the raised signal number to the next eventual.
+//
+// Note that all standard signal handling constraints still apply,
+// i.e., you can't have more than one handler for the same signal,
+// which in this case means you can't have more than one of
+// outstanding calls to this function with the same signal.
+//
+// NOTE: we take an array instead of a 'std::initializer_list' because
+// then we can 'std::move()' into 'Iterate()' without a copy.
+template <typename T, size_t n>
+auto WaitForSignal(T(&&signums)[n]) {
+  return Iterate(std::move(signums))
+      | Concurrent([]() {
+           return Map([](int signum) {
+             return Signal(signum)
+                 | Just(signum);
+           });
+         })
+      | Head();
 }
 
 ////////////////////////////////////////////////////////////////////////

--- a/eventuals/signal.h
+++ b/eventuals/signal.h
@@ -13,14 +13,14 @@ namespace eventuals {
 
 ////////////////////////////////////////////////////////////////////////
 
-inline auto Signal(EventLoop& loop, const int& signum) {
-  return loop.Signal(signum);
+inline auto WaitForSignal(EventLoop& loop, int signum) {
+  return loop.WaitForSignal(signum);
 }
 
 ////////////////////////////////////////////////////////////////////////
 
-inline auto Signal(const int& signum) {
-  return EventLoop::Default().Signal(signum);
+inline auto WaitForSignal(int signum) {
+  return EventLoop::Default().WaitForSignal(signum);
 }
 
 ////////////////////////////////////////////////////////////////////////
@@ -35,12 +35,12 @@ inline auto Signal(const int& signum) {
 //
 // NOTE: we take an array instead of a 'std::initializer_list' because
 // then we can 'std::move()' into 'Iterate()' without a copy.
-template <typename T, size_t n>
-auto WaitForSignal(T(&&signums)[n]) {
+template <size_t N>
+auto WaitForOneOfSignals(int(&&signums)[N]) {
   return Iterate(std::move(signums))
       | Concurrent([]() {
            return Map([](int signum) {
-             return Signal(signum)
+             return WaitForSignal(signum)
                  | Just(signum);
            });
          })

--- a/test/signal.cc
+++ b/test/signal.cc
@@ -12,9 +12,9 @@
 using eventuals::EventLoop;
 using eventuals::Eventual;
 using eventuals::Interrupt;
-using eventuals::Signal;
 using eventuals::Terminate;
 using eventuals::Then;
+using eventuals::WaitForOneOfSignals;
 using eventuals::WaitForSignal;
 
 using namespace std::chrono_literals;
@@ -33,7 +33,7 @@ class SignalTest : public EventLoopTest {};
 #if !defined(_WIN32)
 
 TEST_F(SignalTest, SignalComposition) {
-  auto e = Signal(SIGQUIT)
+  auto e = WaitForSignal(SIGQUIT)
       | Then([]() {
              return "quit";
            });
@@ -61,7 +61,7 @@ TEST_F(SignalTest, SignalComposition) {
 }
 
 TEST_F(SignalTest, WaitForSignal) {
-  auto e = WaitForSignal({SIGQUIT});
+  auto e = WaitForOneOfSignals({SIGQUIT});
 
   auto [future, k] = Terminate(std::move(e));
 
@@ -89,7 +89,7 @@ TEST_F(SignalTest, WaitForSignal) {
 
 
 TEST_F(SignalTest, SignalInterrupt) {
-  auto [future, k] = Terminate(Signal(SIGINT));
+  auto [future, k] = Terminate(WaitForSignal(SIGINT));
 
   Interrupt interrupt;
 

--- a/test/signal.cc
+++ b/test/signal.cc
@@ -15,6 +15,7 @@ using eventuals::Interrupt;
 using eventuals::Signal;
 using eventuals::Terminate;
 using eventuals::Then;
+using eventuals::WaitForSignal;
 
 using namespace std::chrono_literals;
 
@@ -57,6 +58,31 @@ TEST_F(SignalTest, SignalComposition) {
   EventLoop::Default().Run();
 
   EXPECT_EQ(future.get(), "quit");
+}
+
+TEST_F(SignalTest, WaitForSignal) {
+  auto e = WaitForSignal({SIGQUIT});
+
+  auto [future, k] = Terminate(std::move(e));
+
+  k.Start();
+
+  // NOTE: now that we've started the continuation 'k' we will have
+  // submitted a callback to the event loop and thus by explicitly
+  // submitting another callback we will ensure there is a
+  // happens-before relationship between setting up the signal handler
+  // and raising the signal.
+  EventLoop::Waiter waiter(&EventLoop::Default(), "raise(SIGQUIT)");
+
+  EventLoop::Default().Submit(
+      []() {
+        EXPECT_EQ(raise(SIGQUIT), 0);
+      },
+      &waiter);
+
+  EventLoop::Default().Run();
+
+  EXPECT_EQ(future.get(), SIGQUIT);
 }
 
 #endif // !defined(_WIN32)


### PR DESCRIPTION
The current helpers for signal handling are relatively low-level as
they were designed to wrap the low-level 'uv_signal*()' family of
functions. In practice we often want to be able to specify multiple
signals and find out which signal was raised; this commit introduces
the helper 'WaitForSignal()' which does just that.