### PR TITLE
Remove redundant code

### DIFF
--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -24,11 +24,6 @@ jobs:
       - name: Check for bazel
         run: bazel --version
 
-      - name: Install LLVM and Clang
-        uses: KyleMayes/install-llvm-action@v1
-        with:
-          version: "12.0"  
-
       - name: Build
         run: bazel build --spawn_strategy=local --copt="-g" --strip="never" :eventuals
 


### PR DESCRIPTION
We wanna remove this part of code. Check [this](https://github.com/actions/virtual-environments/blob/main/images/linux/Ubuntu2004-README.md) link. They've updated repo, so on Ubuntu 20.04 we already have preinstalled Clang. That's why ` KyleMayes/install-llvm-action` is already not relevant for us.
 