### PR TITLE
Skip build-and-test hooks for markdown commits

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -5,9 +5,13 @@ on:
   push:
     branches:
       - "**"
+    paths-ignore:
+      - '**.md'
   pull_request:
     branches:
       - "main"
+    paths-ignore:
+      - '**.md'
 
 jobs:
   build-and-test:

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -5,9 +5,13 @@ on:
   push:
     branches:
       - "**"
+    paths-ignore:
+      - '**.md'
   pull_request:
     branches:
       - "main"
+    paths-ignore:
+      - '**.md'
 
 jobs:
   build-and-test:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -5,9 +5,13 @@ on:
   push:
     branches:
       - "**"
+    paths-ignore:
+      - '**.md'
   pull_request:
     branches:
       - "main"
+    paths-ignore:
+      - '**.md'
 
 jobs:
   build-and-test:


### PR DESCRIPTION
Changelists that only affect markdown files shouldn't affect the result
of any builds or tests: skip build-and-test actions on commits that only
touch markdown files.

This should vastly reduce the time it takes to merge documentation PRs
into main, and it will also avoid wasting compute running tests on no-op
commits.

This change was inspired by tests running for 30 minutes on the
markdown-only change https://github.com/3rdparty/eventuals/pull/165
which both delayed submission and wasted compute resources.
