### PR TITLE
Introduce clang-tidy review on source files

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -5,5 +5,11 @@ build:windows --compiler="clang-cl"
 
 build:clang --action_env=CC=clang
 
+# Required for bazel_clang_tidy to operate as expected
+build:clang-tidy --aspects @bazel_clang_tidy//clang_tidy:clang_tidy.bzl%clang_tidy_aspect
+build:clang-tidy --output_groups=report
+# Optionally override the .clang-tidy config file target
+build:clang-tidy --@bazel_clang_tidy//:clang_tidy_config=//:clang_tidy_config
+
 # Allow users to add local preferences.
 try-import %workspace%/user.bazelrc

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,11 @@
+UseColor: true
+
+# Discuss if we wanna add some extra checks.
+Checks: "bugprone-*,
+    cppcoreguidelines-*,
+    google-*,
+    performance-*,"
+
+HeaderFilterRegex: "^(eventuals\/.*|test\/.*)"
+
+WarningsAsErrors: ""

--- a/.github/workflows/clang-tidy-review.yml
+++ b/.github/workflows/clang-tidy-review.yml
@@ -1,0 +1,30 @@
+name: clang-tidy-review
+
+on:
+  push:
+    branches:
+      - "**"
+    paths-ignore:
+      - '**.md'
+  pull_request:
+    branches:
+      - "main"
+    paths-ignore:
+      - '**.md'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+
+    # There is no clang-tidy preinstalled on ubuntu.
+    # So we need to install it.
+    - name: Install clang-tidy
+      run: | 
+        sudo apt-get install -y clang-tidy-12
+        sudo ln -s $(which clang-tidy-12) /usr/bin/clang-tidy
+      
+    - name: Run clang-tidy checks 
+      run: bazel build //... --config clang-tidy

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,6 +1,21 @@
 load("@rules_cc//cc:defs.bzl", "cc_library")
 load("//bazel:copts.bzl", "copts")
 
+# If we would like to override the default clang tidy configuration
+# then we can reconfigure the default target from the command line.
+# To do this we must make a filegroup target that has the
+# .clang-tidy config file as a data dependency.
+filegroup(
+    name = "clang_tidy_config",
+    data = [".clang-tidy"],
+    visibility = ["//visibility:public"],
+)
+
+exports_files(
+    [".clang-tidy"],
+    visibility = ["//:__subpackages__"],
+)
+
 cc_library(
     name = "eventuals-base",
     srcs = [

--- a/bazel/deps.bzl
+++ b/bazel/deps.bzl
@@ -1,5 +1,6 @@
 """Dependency specific initialization."""
 
+load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe")
 load("@com_github_3rdparty_bazel_rules_curl//bazel:deps.bzl", curl_deps = "deps")
@@ -53,4 +54,13 @@ def deps(repo_mapping = {}):
         sha256 = "9dc9157a9a1551ec7a7e43daea9a694a0bb5fb8bec81235d8a1e6ef64c716dcb",
         strip_prefix = "googletest-release-1.10.0",
         repo_mapping = repo_mapping,
+    )
+
+    maybe(
+        git_repository,
+        name = "bazel_clang_tidy",
+        commit = "c2fe98cfec0430e78bff4169e9ca0a43123e4c99",
+        remote = "https://github.com/erenon/bazel_clang_tidy",
+        repo_mapping = repo_mapping,
+        shallow_since = "1641482001 +0100",
     )


### PR DESCRIPTION
This PR adds possibility to use `clang-tidy` tool for diagnosing and fixing typical programming errors, like style violations, interface misuse, or bugs that can be deduced via static analysis.
You can treat this PR like a draft PR cause some of the stuff I will transfer to `dev-tools` [maybe], also there are some errors when we are building all stuff (see `clang-tidy-review.yml`). 
![1](https://user-images.githubusercontent.com/68085133/149539473-7bf7b388-266e-4f60-9d5e-6d37a9329c61.png)

I was basing on [this](https://github.com/erenon/bazel_clang_tidy) stuff.