### PR TITLE
Expose ConditionVariable lock

### DIFF
--- a/eventuals/lock.h
+++ b/eventuals/lock.h
@@ -720,6 +720,10 @@ class ConditionVariable {
     return Wait(EmptyCondition());
   }
 
+  Lock* lock() {
+    return lock_;
+  }
+
   void Notify() {
     CHECK(lock_->OwnedByCurrentSchedulerContext());
     Waiter* waiter = head_;


### PR DESCRIPTION
Having access to the underlying lock makes it easier to do the
`Acquire`/`Release` dance around the ConditionVariable's `Wait` method.