### PR TITLE
Add pull_request trigger for GitHub action

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -4,9 +4,12 @@ name: Build and Run all tests
 on:
   push:
     branches:
-      - "**"
+      - "main"
     paths-ignore:
       - "**.md"
+  pull_request:
+    paths-ignore:
+      - "**.md"   
   
 jobs:
   build-and-test:

--- a/.github/workflows/check_code_style.yml
+++ b/.github/workflows/check_code_style.yml
@@ -3,7 +3,10 @@ name: Check Code Style
 on:
   push:
     branches:
-      - "**"
+      - "main"
+  pull_request:
+    paths-ignore:
+      - "**.md"       
 
 jobs:
   check_code_style:
@@ -11,7 +14,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         with: 
-          submodules: 'true'
+          submodules: 'recursive'
 
       # If we do not have clang-format preinstalled => 
       # our workflow will fail.


### PR DESCRIPTION
Now the strategy is that build action will trigger on every
pull request and on any push to `main` branch. Thus there will
not be duplicate workflows.