### PR TITLE
Simplify caller's logic for code style checks

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -1,6 +1,11 @@
 # Workflow for building and testing eventuals on macOS, Ubuntu and Windows.  
 name: Build and Run all tests
 
+# We use action's triggers 'push' and 'pull_request'.
+# The strategy is the following: this action will be
+# triggered on any push to 'main' branch and any pull
+# request to any branch. Thus we avoid duplicate work-
+# flows.
 on:
   push:
     branches:

--- a/.github/workflows/check_code_style.yml
+++ b/.github/workflows/check_code_style.yml
@@ -1,52 +1,42 @@
 name: Check Code Style
 
+# We use action's triggers 'push' and 'pull_request'.
+# The strategy is the following: this action will be
+# triggered on any push to 'main' branch and any pull
+# request to any branch. Thus we avoid duplicate work-
+# flows.
 on:
   push:
     branches:
       - "main"
+    paths-ignore:
+      - "**.md" 
   pull_request:
     paths-ignore:
       - "**.md"       
 
 jobs:
   check_code_style:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: ["ubuntu-latest"]
+
     steps:
+      # We should checkout the repo with submodules
+      # cause we need to have symlink to 
+      # dev-tools/.clang-format file for all code
+      # style checks.
       - uses: actions/checkout@v2
         with: 
           submodules: 'recursive'
 
-      # If we do not have clang-format preinstalled => 
-      # our workflow will fail.
-      - name: Check clang-format version
-        run: clang-format --version
-
-      # IMPORTANT NOTE
-      # https://github.com/actions/virtual-environments/blob/main/images/linux/Ubuntu2004-Readme.md
-      # If you check the link above you will see that on Ubuntu 20.04
-      # we have preinstalled clang-format-10/11/12. By default the symlink
-      # to /usr/bin/clang-format-11 is set. That's why we will not be able
-      # to run successfully the checks for code style cause the minimum
-      # version required is `12` (see `dev-tools/check-code-style/check_style.sh` 
-      # especially check_clang_format() function).
-      # That's why the main idea of this step is just setting the symlink to
-      # /usr/bin/clang-format-12, nothing more. Thus we will be able to run all
-      # checks with correct version of clang-format using GitHub Actions. 
-      - name: Create symlink to /usr/bin/clang-format-12
-        run: |
-          # Before we recreate the symlink we should delete
-          # the existing one.
-          sudo rm /etc/alternatives/clang-format
-
-          # Recreate symlink 'clang-format'
-          sudo ln -s /usr/bin/clang-format-12 /etc/alternatives/clang-format 
-        shell: bash          
-
       # Call the composite action to check files
       # for correct code style. This action (action.yml)
-      # is in `3rdparty/dev-tools/check-code-style` submodule's
-      # directory.
+      # is in `dev-tools` submodule.
       - uses: ./dev-tools/check-code-style
+        with: 
+          os: ${{matrix.os}}
 
       - name: Debug using tmate (if failure)
         if: ${{ failure() }}


### PR DESCRIPTION
We've transferred all preparations like creating symlink
to dev-tools/check-code-style/action.yml to simplify the
code style caller (check_code_style.yml).