### PR TITLE
Fix bug in condition variable's waiters

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,5 @@
 [submodule "dev-tools"]
 	path = dev-tools
 	url = https://github.com/3rdparty/dev-tools.git
+	branch = main
+


### PR DESCRIPTION
Before this commit a `Waiter` was added to the pending list of waiters no matter if they were done waiting or not, potentially leading to a use-after-free error.

Bonus commit: The PR contains an extra commit to add a `branch = main` to the `dev-tools` submodule.