### PR TITLE
Reorder eventuals continuation 'k_' to be last

### DIFF
--- a/eventuals/concurrent-ordered.h
+++ b/eventuals/concurrent-ordered.h
@@ -90,8 +90,6 @@ struct _ReorderAdaptor {
       upstream_->Done();
     }
 
-    K_ k_;
-
     TypeErasedStream* upstream_ = nullptr;
 
     std::map<int, std::deque<Value_>> buffer_;
@@ -101,6 +99,12 @@ struct _ReorderAdaptor {
     std::map<int, bool> ended_;
 
     bool done_ = false;
+
+    // NOTE: we store 'k_' as the _last_ member so it will be
+    // destructed _first_ and thus we won't have any use-after-delete
+    // issues during destruction of 'k_' if it holds any references or
+    // pointers to any (or within any) of the above members.
+    K_ k_;
   };
 
   // Arg there will be received from 'Concurrent::ConcurrentOrderedAdaptor'
@@ -190,13 +194,17 @@ struct _ConcurrentOrderedAdaptor {
       upstream_->Done();
     }
 
-    K_ k_;
-
     bool ended_ = false;
 
     std::optional<int> index_;
 
     TypeErasedStream* upstream_;
+
+    // NOTE: we store 'k_' as the _last_ member so it will be
+    // destructed _first_ and thus we won't have any use-after-delete
+    // issues during destruction of 'k_' if it holds any references or
+    // pointers to any (or within any) of the above members.
+    K_ k_;
   };
 
   struct Composable {

--- a/eventuals/flat-map.h
+++ b/eventuals/flat-map.h
@@ -56,10 +56,9 @@ struct _FlatMap {
 
   template <typename K_, typename F_, typename Arg_>
   struct Continuation : public TypeErasedStream {
-    // NOTE: explicit constructor because inheriting 'TypeErasedStream'.
     Continuation(K_ k, F_ f)
-      : k_(std::move(k)),
-        f_(std::move(f)) {}
+      : f_(std::move(f)),
+        k_(std::move(k)) {}
 
     void Begin(TypeErasedStream& stream) {
       outer_ = &stream;
@@ -125,7 +124,6 @@ struct _FlatMap {
       });
     }
 
-    K_ k_;
     F_ f_;
 
     TypeErasedStream* outer_ = nullptr;
@@ -143,6 +141,12 @@ struct _FlatMap {
     bool done_ = false;
 
     Scheduler::Context* previous_ = nullptr;
+
+    // NOTE: we store 'k_' as the _last_ member so it will be
+    // destructed _first_ and thus we won't have any use-after-delete
+    // issues during destruction of 'k_' if it holds any references or
+    // pointers to any (or within any) of the above members.
+    K_ k_;
   };
 
   template <typename F_>
@@ -155,7 +159,7 @@ struct _FlatMap {
 
     template <typename Arg, typename K>
     auto k(K k) && {
-      return Continuation<K, F_, Arg>{std::move(k), std::move(f_)};
+      return Continuation<K, F_, Arg>(std::move(k), std::move(f_));
     }
 
     F_ f_;

--- a/eventuals/generator.h
+++ b/eventuals/generator.h
@@ -211,9 +211,9 @@ struct _GeneratorFromToWith {
                 Callback<>,
                 Callback<To_>>&&,
             Callback<>&&>&& dispatch)
-      : k_(std::move(k)),
-        args_(std::move(args)),
-        dispatch_(std::move(dispatch)) {}
+      : args_(std::move(args)),
+        dispatch_(std::move(dispatch)),
+        k_(std::move(k)) {}
 
     // All Continuation functions just trigger dispatch Callback,
     // that stores all callbacks for different events
@@ -292,7 +292,6 @@ struct _GeneratorFromToWith {
           std::move(args_));
     }
 
-    K_ k_;
     std::tuple<Args_...> args_;
 
     Callback<
@@ -318,6 +317,12 @@ struct _GeneratorFromToWith {
 
     std::unique_ptr<void, Callback<void*>> e_;
     Interrupt* interrupt_ = nullptr;
+
+    // NOTE: we store 'k_' as the _last_ member so it will be
+    // destructed _first_ and thus we won't have any use-after-delete
+    // issues during destruction of 'k_' if it holds any references or
+    // pointers to any (or within any) of the above members.
+    K_ k_;
   };
 
   template <typename From_, typename To_, typename... Args_>

--- a/eventuals/loop.h
+++ b/eventuals/loop.h
@@ -24,6 +24,22 @@ struct _Loop {
       typename Value_,
       typename... Errors_>
   struct Continuation {
+    Continuation(
+        Reschedulable<K_, Value_> k,
+        Context_ context,
+        Begin_ begin,
+        Body_ body,
+        Ended_ ended,
+        Fail_ fail,
+        Stop_ stop)
+      : context_(std::move(context)),
+        begin_(std::move(begin)),
+        body_(std::move(body)),
+        ended_(std::move(ended)),
+        fail_(std::move(fail)),
+        stop_(std::move(stop)),
+        k_(std::move(k)) {}
+
     Continuation(Continuation&& that) = default;
 
     Continuation& operator=(Continuation&& that) {
@@ -111,7 +127,6 @@ struct _Loop {
       }
     }
 
-    Reschedulable<K_, Value_> k_;
     Context_ context_;
     Begin_ begin_;
     Body_ body_;
@@ -122,6 +137,12 @@ struct _Loop {
     TypeErasedStream* stream_ = nullptr;
 
     std::optional<Interrupt::Handler> handler_;
+
+    // NOTE: we store 'k_' as the _last_ member so it will be
+    // destructed _first_ and thus we won't have any use-after-delete
+    // issues during destruction of 'k_' if it holds any references or
+    // pointers to any (or within any) of the above members.
+    Reschedulable<K_, Value_> k_;
   };
 
   template <
@@ -185,14 +206,14 @@ struct _Loop {
           Stop_,
           Interruptible_,
           Value_,
-          Errors_...>{
+          Errors_...>(
           Reschedulable<K, Value_>{std::move(k)},
           std::move(context_),
           std::move(begin_),
           std::move(body_),
           std::move(ended_),
           std::move(fail_),
-          std::move(stop_)};
+          std::move(stop_));
     }
 
     template <typename Context>

--- a/eventuals/raise.h
+++ b/eventuals/raise.h
@@ -11,6 +11,10 @@ namespace eventuals {
 struct _Raise {
   template <typename K_, typename T_>
   struct Continuation {
+    Continuation(K_ k, T_ t)
+      : t_(std::move(t)),
+        k_(std::move(k)) {}
+
     template <typename... Args>
     void Start(Args&&...) {
       k_.Fail(std::move(t_));
@@ -29,8 +33,13 @@ struct _Raise {
       k_.Register(interrupt);
     }
 
-    K_ k_;
     T_ t_;
+
+    // NOTE: we store 'k_' as the _last_ member so it will be
+    // destructed _first_ and thus we won't have any use-after-delete
+    // issues during destruction of 'k_' if it holds any references or
+    // pointers to any (or within any) of the above members.
+    K_ k_;
   };
 
   template <typename T_>

--- a/eventuals/static-thread-pool.h
+++ b/eventuals/static-thread-pool.h
@@ -143,13 +143,13 @@ struct _StaticThreadPoolSchedule {
         StaticThreadPool::Requirements* requirements,
         std::string&& name,
         E_ e)
-      : k_(std::move(k)),
-        e_(std::move(e)),
+      : e_(std::move(e)),
         context_(
             std::make_tuple(
                 CHECK_NOTNULL(pool),
                 std::move(name),
-                CHECK_NOTNULL(requirements))) {}
+                CHECK_NOTNULL(requirements))),
+        k_(std::move(k)) {}
 
     // Helper to avoid casting default 'Scheduler*' to 'StaticThreadPool*'
     // each time.
@@ -457,7 +457,6 @@ struct _StaticThreadPoolSchedule {
       }
     }
 
-    K_ k_;
     E_ e_;
 
     std::optional<
@@ -484,6 +483,12 @@ struct _StaticThreadPoolSchedule {
             .template k<Value_>(std::declval<K_>())));
 
     std::unique_ptr<Adapted_> adapted_;
+
+    // NOTE: we store 'k_' as the _last_ member so it will be
+    // destructed _first_ and thus we won't have any use-after-delete
+    // issues during destruction of 'k_' if it holds any references or
+    // pointers to any (or within any) of the above members.
+    K_ k_;
   };
 
   template <typename E_>


### PR DESCRIPTION
By always storing 'k_' as the _last_ member it will be destructed
_first_ and thus we won't have any use-after-delete issues during
destruction of 'k_' if it holds any references or pointers to any (or
within any) of the previous continuations.
    
This fixes 3rdparty/eventuals-grpc#71 and allows us to turn on
building with 'asan' on this repository as well as eventuals-grpc.