### PR TITLE
Log warning to help debug when dereferencing an eventual that fails

### DIFF
--- a/eventuals/terminal.h
+++ b/eventuals/terminal.h
@@ -262,7 +262,18 @@ auto operator*(E e) {
 
   k.Start();
 
-  return future.get();
+  try {
+    return future.get();
+  } catch (const std::exception& e) {
+    LOG(WARNING)
+        << "WARNING: exception thrown while dereferencing eventual: "
+        << e.what();
+    throw;
+  } catch (...) {
+    LOG(WARNING)
+        << "WARNING: exception thrown while dereferencing eventual";
+    throw;
+  }
 }
 
 ////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
@while-false this was inspired from our debugging session, will possibly help track down issues even before pulling out the debugger.