### PR TITLE
Inline a few header methods

### DIFF
--- a/eventuals/rsa.h
+++ b/eventuals/rsa.h
@@ -208,7 +208,7 @@ namespace pem {
 
 // Returns an expected 'std::string' with the encoded private key in
 // PEM format or an unexpected.
-eventuals::Expected::Of<std::string> Encode(EVP_PKEY* key) {
+inline eventuals::Expected::Of<std::string> Encode(EVP_PKEY* key) {
   BIO* bio = BIO_new(BIO_s_mem());
 
   int write = PEM_write_bio_PrivateKey(

--- a/eventuals/x509.h
+++ b/eventuals/x509.h
@@ -491,7 +491,7 @@ namespace pem {
 
 // Returns an expected 'std::string' with the encoded X509 certificate in
 // PEM format or an unexpected.
-eventuals::Expected::Of<std::string> Encode(X509* certificate) {
+inline eventuals::Expected::Of<std::string> Encode(X509* certificate) {
   BIO* bio = BIO_new(BIO_s_mem());
 
   int write = PEM_write_bio_X509(bio, certificate);
@@ -513,7 +513,7 @@ eventuals::Expected::Of<std::string> Encode(X509* certificate) {
 ////////////////////////////////////////////////////////////////////////
 
 // Returns an X509 certificate read from a file in PEM format.
-eventuals::Expected::Of<x509::Certificate> ReadCertificate(
+inline eventuals::Expected::Of<x509::Certificate> ReadCertificate(
     const std::filesystem::path& path) {
   // Using a 'FILE*' here as necessary for 'PEM_read_X509()'.
   FILE* file = fopen(path.string().c_str(), "r");


### PR DESCRIPTION
If these methods are not inlined, they'll cause "duplicate definition"
errors when used in a program that has multiple translation units.

TESTED: caused build failures in upcoming `reboot-dev/respect` change
previously, build failures now resolved.