### PR TITLE
Add Dazel configuration

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -1,4 +1,4 @@
-# Workflow for building and testing eventuals on macOS, Ubuntu and Windows.  
+# Workflow for building and testing eventuals on macOS, Ubuntu and Windows.
 name: Build and Run all tests
 
 # We use action's triggers 'push' and 'pull_request'.
@@ -14,8 +14,8 @@ on:
       - "**.md"
   pull_request:
     paths-ignore:
-      - "**.md"   
-  
+      - "**.md"
+
 jobs:
   build-and-test:
     name: Build and Test
@@ -24,10 +24,21 @@ jobs:
       matrix:
         include:
           - os: macos-latest
+            sudo-command: "sudo"
+            # The macos runner doesn't have `docker` installed, so can't run
+            # `dazel`. Fall back to `bazel`.
+            bazel-command: "bazel"
             bazel-config: ""
           - os: ubuntu-latest
+            sudo-command: "sudo"
+            bazel-command: "dazel"
             bazel-config: "--config=asan"
           - os: windows-2019
+            sudo-command: "" # The Windows runner already runs as root.
+            # Our `dazel` container is based on `ubuntu:latest`, which doesn't
+            # support running on the `windows/amd64` platform. Fall back to
+            # `bazel`.
+            bazel-command: "bazel"
             bazel-config: ""
 
     env:
@@ -41,20 +52,25 @@ jobs:
       # Checkout the repository under $GITHUB_WORKSPACE.
       - uses: actions/checkout@v2
         with:
-          submodules: 'recursive'
+          submodules: "recursive"
+
+      # Install Dazel, so that we use the same build tooling in our Actions as
+      # we do on our workstations.
+      - name: Install Dazel
+        run: ${{ matrix.sudo-command }} pip3 install dazel
 
       - name: Build
         run: |
-          bazel build \
+          ${{ matrix.bazel-command }} build \
             ${BAZEL_CONFIG} \
             --spawn_strategy=local \
             -c dbg \
             --strip="never" \
-            :eventuals       
+            :eventuals
 
       - name: Test
-        run: | 
-          bazel test \
+        run: |
+          ${{ matrix.bazel-command }} test \
             ${BAZEL_CONFIG} \
             --experimental_ui_max_stdouterr_bytes=-1 \
             --spawn_strategy=local \
@@ -67,4 +83,4 @@ jobs:
 
       - name: Debug using tmate (if failure)
         if: ${{ failure() }}
-        uses: mxschmitt/action-tmate@v3  
+        uses: mxschmitt/action-tmate@v3

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -41,9 +41,6 @@ jobs:
             bazel-command: "bazel"
             bazel-config: ""
 
-    env:
-      BAZEL_CONFIG: ${{ matrix.bazel-config }}
-
     defaults:
       run:
         shell: bash
@@ -62,7 +59,7 @@ jobs:
       - name: Build
         run: |
           ${{ matrix.bazel-command }} build \
-            ${BAZEL_CONFIG} \
+            ${{ matrix.bazel-config }} \
             --spawn_strategy=local \
             -c dbg \
             --strip="never" \
@@ -71,7 +68,7 @@ jobs:
       - name: Test
         run: |
           ${{ matrix.bazel-command }} test \
-            ${BAZEL_CONFIG} \
+            ${{ matrix.bazel-config }} \
             --experimental_ui_max_stdouterr_bytes=-1 \
             --spawn_strategy=local \
             -c dbg \

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ bazel-eventuals
 bazel-out
 bazel-testlogs
 user.bazelrc
+.dazel_run

--- a/Dockerfile.dazel
+++ b/Dockerfile.dazel
@@ -1,0 +1,1 @@
+./dev-tools/Dockerfile.dazel

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,0 +1,1 @@
+./WORKSPACE.bazel


### PR DESCRIPTION
Before this PR the `eventuals` repo could only build if you had (the
right version of) `bazel` installed on your machine. To be more hermetic
we'd like to avoid this hope-you-installed-it-right type situations. In
fact, our GitHub Codespaces don't (currently) install `bazel` at all!

This PR adds a symlink to our standard `Dockerfile.dazel` in
the `dev-tools` subrepo, allowing us to use `dazel` to build in a
repeatable way. Dazel will, unfortunately, look for a `WORKSPACE` file
instead of a `WORKSPACE.dazel` file, so we add a symlink to that also.

This is a step towards https://github.com/reboot-dev/company/issues/34