### PR TITLE
Introduce initial support for "static" errors

### DIFF
--- a/eventuals/compose.h
+++ b/eventuals/compose.h
@@ -28,6 +28,74 @@ struct HasValueFrom<T, std::void_t<void_template<T::template ValueFrom>>>
 
 ////////////////////////////////////////////////////////////////////////
 
+template <typename, typename = void>
+struct HasErrorsFrom : std::false_type {};
+
+template <typename T>
+struct HasErrorsFrom<T, std::void_t<void_template<T::template ErrorsFrom>>>
+  : std::true_type {};
+
+////////////////////////////////////////////////////////////////////////
+
+template <
+    typename Arg_,
+    typename Left_,
+    typename Right_,
+    typename Errors_,
+    bool = HasErrorsFrom<Left_>::value,
+    bool = HasErrorsFrom<Right_>::value>
+struct ErrorsFromComposed;
+
+template <
+    typename Arg_,
+    typename Left_,
+    typename Right_,
+    typename Errors_>
+struct ErrorsFromComposed<Arg_, Left_, Right_, Errors_, true, true> {
+  using ValueFrom_ = typename Right_::template ValueFrom<
+      typename Left_::template ValueFrom<Arg_>>;
+
+  using Errors = typename Right_::template ErrorsFrom<
+      ValueFrom_,
+      typename Left_::template ErrorsFrom<Arg_, Errors_>>;
+};
+
+template <
+    typename Arg_,
+    typename Left_,
+    typename Right_,
+    typename Errors_>
+struct ErrorsFromComposed<Arg_, Left_, Right_, Errors_, true, false> {
+  using Errors = typename Left_::template ErrorsFrom<
+      Arg_,
+      tuple_types_union_t<std::tuple<std::exception>, Errors_>>;
+};
+
+template <
+    typename Arg_,
+    typename Left_,
+    typename Right_,
+    typename Errors_>
+struct ErrorsFromComposed<Arg_, Left_, Right_, Errors_, false, true> {
+  using ValueFrom_ = typename Right_::template ValueFrom<
+      typename Left_::template ValueFrom<Arg_>>;
+
+  using Errors = typename Right_::template ErrorsFrom<
+      ValueFrom_,
+      tuple_types_union_t<std::tuple<std::exception>, Errors_>>;
+};
+
+template <
+    typename Arg_,
+    typename Left_,
+    typename Right_,
+    typename Errors_>
+struct ErrorsFromComposed<Arg_, Left_, Right_, Errors_, false, false> {
+  using Errors = tuple_types_union_t<std::tuple<std::exception>, Errors_>;
+};
+
+////////////////////////////////////////////////////////////////////////
+
 template <typename Left_, typename Right_>
 struct Composed final {
   Left_ left_;
@@ -36,6 +104,13 @@ struct Composed final {
   template <typename Arg>
   using ValueFrom = typename Right_::template ValueFrom<
       typename Left_::template ValueFrom<Arg>>;
+
+  template <typename Arg, typename Errors>
+  using ErrorsFrom = typename ErrorsFromComposed<
+      Arg,
+      Left_,
+      Right_,
+      Errors>::Errors;
 
   template <typename Arg>
   auto k() && {

--- a/eventuals/dns-resolver.h
+++ b/eventuals/dns-resolver.h
@@ -25,6 +25,7 @@ inline auto DomainNameResolve(
   return loop.Schedule(
       "DomainNameResolve",
       Eventual<std::string>()
+          .raises<std::runtime_error>()
           .context(Data{loop, address, port})
           .start([](auto& data, auto& k) {
             using K = std::decay_t<decltype(k)>;

--- a/eventuals/filesystem.h
+++ b/eventuals/filesystem.h
@@ -164,6 +164,7 @@ inline auto OpenFile(
   return loop.Schedule(
       "OpenFile",
       Eventual<File>()
+          .raises<std::runtime_error>()
           .context(Data{loop, flags, mode, path})
           .start([](auto& data, auto& k) mutable {
             using K = std::decay_t<decltype(k)>;
@@ -217,6 +218,7 @@ inline auto CloseFile(EventLoop& loop, File&& file) {
   return loop.Schedule(
       "CloseFile",
       Eventual<void>()
+          .raises<std::runtime_error>()
           .context(Data{loop, std::move(file)})
           .start([](auto& data, auto& k) mutable {
             using K = std::decay_t<decltype(k)>;
@@ -273,6 +275,7 @@ inline auto ReadFile(
   return loop.Schedule(
       "ReadFile",
       Eventual<std::string>()
+          .raises<std::runtime_error>()
           .context(Data{loop, file, bytes_to_read, offset, bytes_to_read})
           .start([](auto& data, auto& k) mutable {
             using K = std::decay_t<decltype(k)>;
@@ -333,6 +336,7 @@ inline auto WriteFile(
   return loop.Schedule(
       "WriteFile",
       Eventual<void>()
+          .raises<std::runtime_error>()
           .context(Data{loop, file, data, offset})
           .start([](auto& data, auto& k) mutable {
             using K = std::decay_t<decltype(k)>;
@@ -387,6 +391,7 @@ inline auto UnlinkFile(EventLoop& loop, const std::filesystem::path& path) {
   return loop.Schedule(
       "UnlinkFile",
       Eventual<void>()
+          .raises<std::runtime_error>()
           .context(Data{loop, path})
           .start([](auto& data, auto& k) mutable {
             using K = std::decay_t<decltype(k)>;
@@ -439,6 +444,7 @@ inline auto MakeDirectory(
   return loop.Schedule(
       "MakeDirectory",
       Eventual<void>()
+          .raises<std::runtime_error>()
           .context(Data{loop, path, mode})
           .start([](auto& data, auto& k) mutable {
             using K = std::decay_t<decltype(k)>;
@@ -490,6 +496,7 @@ inline auto RemoveDirectory(
   return loop.Schedule(
       "RemoveDirectory",
       Eventual<void>()
+          .raises<std::runtime_error>()
           .context(Data{loop, path})
           .start([](auto& data, auto& k) mutable {
             using K = std::decay_t<decltype(k)>;
@@ -544,6 +551,7 @@ inline auto CopyFile(
   return loop.Schedule(
       "CopyFile",
       Eventual<void>()
+          .raises<std::runtime_error>()
           .context(Data{loop, src, dst, flags})
           .start([](auto& data, auto& k) mutable {
             using K = std::decay_t<decltype(k)>;
@@ -601,6 +609,7 @@ inline auto RenameFile(
   return loop.Schedule(
       "RenameFile",
       Eventual<void>()
+          .raises<std::runtime_error>()
           .context(Data{loop, src, dst})
           .start([](auto& data, auto& k) mutable {
             using K = std::decay_t<decltype(k)>;

--- a/eventuals/raise.h
+++ b/eventuals/raise.h
@@ -47,6 +47,9 @@ struct _Raise final {
     template <typename Arg>
     using ValueFrom = Arg;
 
+    template <typename Arg, typename Errors>
+    using ErrorsFrom = tuple_types_union_t<std::tuple<T_>, Errors>;
+
     template <typename Arg, typename K>
     auto k(K k) && {
       return Continuation<K, T_>{std::move(k), std::move(t_)};

--- a/eventuals/task.h
+++ b/eventuals/task.h
@@ -635,6 +635,7 @@ struct Task final {
     // for the 'Error' type.
     return [error = std::make_unique<Error>(std::move(error))]() mutable {
       return Eventual<_TaskFailure>()
+          .raises<Error>()
           .start([&](auto& k) mutable {
             k.Fail(Error(std::move(*error)));
           });

--- a/eventuals/then.h
+++ b/eventuals/then.h
@@ -18,6 +18,18 @@ using ValueFromMaybeComposable = typename std::conditional_t<
 
 ////////////////////////////////////////////////////////////////////////
 
+template <typename T, typename Arg, typename Errors>
+using ErrorsFromMaybeComposable = typename ErrorsFromComposed<
+    Arg,
+    std::conditional_t<
+        !HasValueFrom<T>::value,
+        decltype(Just()),
+        T>,
+    decltype(Just()),
+    Errors>::Errors;
+
+////////////////////////////////////////////////////////////////////////
+
 struct _Then final {
   template <typename K_>
   struct Adaptor final {
@@ -62,6 +74,15 @@ struct _Then final {
             std::invoke_result<F_>,
             std::invoke_result<F_, Arg>>::type,
         void>;
+
+    template <typename Arg, typename Errors>
+    using ErrorsFrom = ErrorsFromMaybeComposable<
+        typename std::conditional_t<
+            std::is_void_v<Arg>,
+            std::invoke_result<F_>,
+            std::invoke_result<F_, Arg>>::type,
+        void,
+        Errors>;
 
     template <typename Arg, typename K>
     auto k(K k) && {

--- a/test/BUILD.bazel
+++ b/test/BUILD.bazel
@@ -86,6 +86,7 @@ cc_test(
         "then.cc",
         "timer.cc",
         "transformer.cc",
+        "type-traits.cc",
         "unpack.cc",
     ],
     copts = copts(),

--- a/test/concurrent-downstream-done-one-eventual-fail.cc
+++ b/test/concurrent-downstream-done-one-eventual-fail.cc
@@ -33,6 +33,7 @@ TYPED_TEST(ConcurrentTypedTest, DownstreamDoneOneEventualFail) {
             return Map(Let([&](int& i) {
               return Eventual<std::string>()
                   .interruptible()
+                  .raises()
                   .start([&](auto& k, Interrupt::Handler& handler) mutable {
                     if (i == 1) {
                       callbacks.emplace_back([&k]() {

--- a/test/concurrent-emit-fail-interrupt.cc
+++ b/test/concurrent-emit-fail-interrupt.cc
@@ -46,10 +46,12 @@ TYPED_TEST(ConcurrentTypedTest, EmitFailInterrupt) {
                })
         | this->ConcurrentOrConcurrentOrdered([&]() {
             return Map(Let([&](int& i) {
-              return Eventual<std::string>([&](auto& k) {
-                k.Fail(std::runtime_error("error"));
-                interrupt.Trigger();
-              });
+              return Eventual<std::string>()
+                  .raises()
+                  .start([&](auto& k) {
+                    k.Fail(std::runtime_error("error"));
+                    interrupt.Trigger();
+                  });
             }));
           })
         | Collect<std::vector<std::string>>();

--- a/test/concurrent-fail-before-start.cc
+++ b/test/concurrent-fail-before-start.cc
@@ -32,8 +32,9 @@ TYPED_TEST(ConcurrentTypedTest, FailBeforeStart) {
               int i;
             };
             return Map(Let([&](int& i) {
-              return Eventual<std::string>(
-                  [&, data = Data()](auto& k) mutable {
+              return Eventual<std::string>()
+                  .raises()
+                  .start([&, data = Data()](auto& k) mutable {
                     using K = std::decay_t<decltype(k)>;
                     data.k = &k;
                     data.i = i;

--- a/test/concurrent-fail-or-stop.cc
+++ b/test/concurrent-fail-or-stop.cc
@@ -31,8 +31,9 @@ TYPED_TEST(ConcurrentTypedTest, FailOrStop) {
               int i;
             };
             return Map(Let([&](int& i) {
-              return Eventual<std::string>(
-                  [&, data = Data()](auto& k) mutable {
+              return Eventual<std::string>()
+                  .raises()
+                  .start([&, data = Data()](auto& k) mutable {
                     using K = std::decay_t<decltype(k)>;
                     data.k = &k;
                     data.i = i;

--- a/test/concurrent-fail.cc
+++ b/test/concurrent-fail.cc
@@ -32,8 +32,9 @@ TYPED_TEST(ConcurrentTypedTest, Fail) {
               int i;
             };
             return Map(Let([&](int& i) {
-              return Eventual<std::string>(
-                  [&, data = Data()](auto& k) mutable {
+              return Eventual<std::string>()
+                  .raises()
+                  .start([&, data = Data()](auto& k) mutable {
                     using K = std::decay_t<decltype(k)>;
                     data.k = &k;
                     data.i = i;

--- a/test/concurrent-interrupt-fail-or-stop.cc
+++ b/test/concurrent-interrupt-fail-or-stop.cc
@@ -35,6 +35,7 @@ TYPED_TEST(ConcurrentTypedTest, InterruptFailOrStop) {
             return Map(Let([&](int& i) {
               return Eventual<std::string>()
                   .interruptible()
+                  .raises()
                   .start([&](auto& k, Interrupt::Handler& handler) mutable {
                     if (i == 1) {
                       handler.Install([&k]() {

--- a/test/concurrent-interrupt-fail.cc
+++ b/test/concurrent-interrupt-fail.cc
@@ -34,6 +34,7 @@ TYPED_TEST(ConcurrentTypedTest, InterruptFail) {
             return Map(Let([&](int& i) {
               return Eventual<std::string>()
                   .interruptible()
+                  .raises()
                   .start([&](auto& k, Interrupt::Handler& handler) mutable {
                     handler.Install([&k]() {
                       k.Fail(std::runtime_error("error"));

--- a/test/conditional.cc
+++ b/test/conditional.cc
@@ -95,6 +95,7 @@ TEST(ConditionalTest, Fail) {
 
   auto c = [&]() {
     return Eventual<int>()
+               .raises<std::runtime_error>()
                .start([](auto& k) {
                  auto thread = std::thread(
                      [&k]() mutable {

--- a/test/do-all.cc
+++ b/test/do-all.cc
@@ -46,7 +46,9 @@ TEST(DoAllTest, Succeed) {
 TEST(DoAllTest, Fail) {
   auto e = []() {
     return DoAll(
-        Eventual<void>([](auto& k) { k.Fail(std::runtime_error("error")); }),
+        Eventual<void>()
+            .raises<std::runtime_error>()
+            .start([](auto& k) { k.Fail(std::runtime_error("error")); }),
         Eventual<int>([](auto& k) { k.Start(42); }),
         Eventual<std::string>([](auto& k) { k.Start(std::string("hello")); }),
         Eventual<void>([](auto& k) { k.Start(); }));

--- a/test/eventual.cc
+++ b/test/eventual.cc
@@ -79,6 +79,7 @@ TEST(EventualTest, Fail) {
 
   auto e = [&]() {
     return Eventual<int>()
+               .raises()
                .context("error")
                .start([](auto& error, auto& k) {
                  auto thread = std::thread(
@@ -224,8 +225,15 @@ TEST(EventualTest, Just) {
 TEST(EventualTest, Raise) {
   auto e = []() {
     return Just(42)
-        | Raise("error");
+        | Raise("error")
+        | Raise("another error")
+        | Just(12);
   };
+
+  static_assert(
+      eventuals::tuple_types_unordered_equals_v<
+          decltype(e())::ErrorsFrom<void, std::tuple<>>,
+          std::tuple<std::runtime_error>>);
 
   EXPECT_THROW_WHAT(*e(), "error");
 }

--- a/test/generator.cc
+++ b/test/generator.cc
@@ -214,6 +214,7 @@ TEST(Generator, FailStream) {
 
   auto e = [&]() {
     return Eventual<int>()
+               .raises<std::runtime_error>()
                .start([](auto& k) {
                  k.Fail(std::runtime_error("error"));
                })

--- a/test/lock.cc
+++ b/test/lock.cc
@@ -91,6 +91,7 @@ TEST(LockTest, Fail) {
   auto e1 = [&]() {
     return Acquire(&lock)
         | Eventual<std::string>()
+              .raises<std::runtime_error>()
               .start([](auto& k) {
                 auto thread = std::thread(
                     [&k]() mutable {

--- a/test/repeat.cc
+++ b/test/repeat.cc
@@ -60,6 +60,7 @@ TEST(RepeatTest, Succeed) {
 TEST(RepeatTest, Fail) {
   auto e = [](auto) {
     return Eventual<int>()
+        .raises<std::runtime_error>()
         .start([](auto& k) {
           k.Fail(std::runtime_error("error"));
         });

--- a/test/task.cc
+++ b/test/task.cc
@@ -96,6 +96,7 @@ TEST(Task, FailOnCallback) {
   auto e = [&]() -> Task::Of<int> {
     return [&]() {
       return Eventual<int>()
+                 .raises<std::runtime_error>()
                  .start([](auto& k) {
                    k.Fail(std::runtime_error("error from start"));
                  })
@@ -113,7 +114,8 @@ TEST(Task, FailOnCallback) {
                 })
                 .fail([&](auto& k, auto&& error) {
                   functions.fail.Call();
-                  k.Fail(std::move(error));
+                  k.Fail(eventuals::make_exception_ptr_or_forward(
+                      std::forward<decltype(error)>(error)));
                 });
     };
   };
@@ -130,6 +132,7 @@ TEST(Task, FailTerminated) {
   auto e = [&]() -> Task::Of<int> {
     return [&]() {
       return Eventual<int>()
+                 .raises<std::runtime_error>()
                  .start([](auto& k) {
                    k.Fail(std::runtime_error("error from start"));
                  })
@@ -330,6 +333,7 @@ TEST(Task, FromToFail) {
 
   auto e = [&]() {
     return Eventual<int>()
+               .raises<std::runtime_error>()
                .start([](auto& k) {
                  k.Fail(std::runtime_error("error"));
                })

--- a/test/then.cc
+++ b/test/then.cc
@@ -54,6 +54,7 @@ TEST(ThenTest, Fail) {
 
   auto c = [&]() {
     return Eventual<int>()
+               .raises<std::runtime_error>()
                .start([](auto& k) {
                  auto thread = std::thread(
                      [&k]() mutable {

--- a/test/transformer.cc
+++ b/test/transformer.cc
@@ -208,9 +208,11 @@ TEST(Transformer, PropagateFail) {
   auto transformer = []() {
     return Transformer::From<int>::To<std::string>([]() {
       return Map(Let([](auto& i) {
-        return Eventual<std::string>([](auto& k) {
-          k.Fail(std::runtime_error("error"));
-        });
+        return Eventual<std::string>()
+            .raises<std::runtime_error>()
+            .start([](auto& k) {
+              k.Fail(std::runtime_error("error"));
+            });
       }));
     });
   };

--- a/test/type-traits.cc
+++ b/test/type-traits.cc
@@ -1,0 +1,110 @@
+#include "eventuals/type-traits.h"
+
+#include <string>
+
+using eventuals::tuple_types_subset_v;
+using eventuals::tuple_types_union_t;
+using eventuals::tuple_types_unordered_equals_v;
+using eventuals::types_contains_v;
+
+////////////////////////////////////////////////////////////////////////
+
+static_assert(types_contains_v<int, double, int>);
+
+static_assert(!types_contains_v<int, double, const char*>);
+
+////////////////////////////////////////////////////////////////////////
+
+static_assert(
+    tuple_types_subset_v<
+        std::tuple<int>,
+        std::tuple<int>>);
+
+static_assert(
+    !tuple_types_subset_v<
+        std::tuple<std::string>,
+        std::tuple<int>>);
+
+static_assert(
+    tuple_types_subset_v<
+        std::tuple<>,
+        std::tuple<int>>);
+
+static_assert(
+    tuple_types_subset_v<
+        std::tuple<int>,
+        std::tuple<int, double>>);
+
+static_assert(
+    !tuple_types_subset_v<
+        std::tuple<int>,
+        std::tuple<double, std::string>>);
+
+static_assert(
+    tuple_types_subset_v<
+        std::tuple<int, std::string>,
+        std::tuple<int, double, std::string>>);
+
+////////////////////////////////////////////////////////////////////////
+
+static_assert(
+    tuple_types_unordered_equals_v<
+        std::tuple<>,
+        std::tuple<>>);
+
+static_assert(
+    !tuple_types_unordered_equals_v<
+        std::tuple<>,
+        std::tuple<int>>);
+
+static_assert(
+    !tuple_types_unordered_equals_v<
+        std::tuple<int>,
+        std::tuple<>>);
+
+static_assert(
+    tuple_types_unordered_equals_v<
+        std::tuple<int>,
+        std::tuple<int>>);
+
+static_assert(
+    tuple_types_unordered_equals_v<
+        std::tuple<int, std::string>,
+        std::tuple<std::string, int>>);
+
+static_assert(
+    !tuple_types_unordered_equals_v<
+        std::tuple<int, std::string>,
+        std::tuple<std::string, int, double>>);
+
+////////////////////////////////////////////////////////////////////////
+
+static_assert(
+    std::is_same_v<
+        tuple_types_union_t<
+            std::tuple<>,
+            std::tuple<>>,
+        std::tuple<>>);
+
+static_assert(
+    std::is_same_v<
+        tuple_types_union_t<
+            std::tuple<>,
+            std::tuple<int>>,
+        std::tuple<int>>);
+
+static_assert(
+    std::is_same_v<
+        tuple_types_union_t<
+            std::tuple<int>,
+            std::tuple<>>,
+        std::tuple<int>>);
+
+static_assert(
+    std::is_same_v<
+        tuple_types_union_t<
+            std::tuple<int>,
+            std::tuple<int>>,
+        std::tuple<int>>);
+
+////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Previously there was no way to know, or track, what errors might
propagate through a an eventual pipeline. This commit introduces the
initial components necessary to do that.

Next step is to add 'ErrorsFrom' to all eventual types and then update
'Composed' to not use 'ErrorsFromComposed' but instead assume that all
eventuals that are composed 'HaveErrorsFrom'.