### PR TITLE
Add remote cache support

### DIFF
--- a/.dazelrc
+++ b/.dazelrc
@@ -1,0 +1,7 @@
+#!/usr/bin/env python
+# This configuration file is effectively a python module loaded by dazel
+import os.path
+
+DAZEL_ENV_VARS=["GOOGLE_APPLICATION_CREDENTIALS=/tmp/service_account_credentials.json"]
+DAZEL_VOLUMES=["/tmp:/tmp"]
+

--- a/.dazelrc
+++ b/.dazelrc
@@ -1,7 +1,0 @@
-#!/usr/bin/env python
-# This configuration file is effectively a python module loaded by dazel
-import os.path
-
-DAZEL_ENV_VARS=["GOOGLE_APPLICATION_CREDENTIALS=/tmp/service_account_credentials.json"]
-DAZEL_VOLUMES=["/tmp:/tmp"]
-

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -10,6 +10,7 @@ on:
   push:
     branches:
       - "main"
+      - "bulat.add-remote-cache"
     paths-ignore:
       - "**.md"
   pull_request:

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -24,23 +24,23 @@ jobs:
     strategy:
       matrix:
         include:
-#          - os: macos-latest
-#            sudo-command: "sudo"
-#            # The macos runner doesn't have `docker` installed, so can't run
-#            # `dazel`. Fall back to `bazel`.
-#            bazel-command: "bazel"
-#            bazel-config: ""
+          - os: macos-latest
+            sudo-command: "sudo"
+            # The macos runner doesn't have `docker` installed, so can't run
+            # `dazel`. Fall back to `bazel`.
+            bazel-command: "bazel"
+            bazel-config: ""
           - os: ubuntu-latest
             sudo-command: "sudo"
             bazel-command: "dazel"
             bazel-config: "--config=asan"
-#          - os: windows-2019
-#            sudo-command: "" # The Windows runner already runs as root.
-#            # Our `dazel` container is based on `ubuntu:latest`, which doesn't
-#            # support running on the `windows/amd64` platform. Fall back to
-#            # `bazel`.
-#            bazel-command: "bazel"
-#            bazel-config: ""
+          - os: windows-2019
+            sudo-command: "" # The Windows runner already runs as root.
+            # Our `dazel` container is based on `ubuntu:latest`, which doesn't
+            # support running on the `windows/amd64` platform. Fall back to
+            # `bazel`.
+            bazel-command: "bazel"
+            bazel-config: ""
 
     defaults:
       run:
@@ -59,11 +59,8 @@ jobs:
       - name: Set up remote cache credentials (1)
         uses: jsdaniell/create-json@1.1.2
         with:
-          name: "service_account_credentials.json"
+          name: ${{ env.GOOGLE_APPLICATION_CREDENTIALS }}
           json: ${{ secrets.GCP_GITHUB_INFRA_REMOTE_CACHE_CREDENTIALS }}
-
-#      - name: Set up remote cache credentials (2)
-#        run: mv ./service_account_credentials.json $GOOGLE_APPLICATION_CREDENTIALS
 
       # Install Dazel, so that we use the same build tooling in our Actions as
       # we do on our workstations.

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -45,11 +45,24 @@ jobs:
       run:
         shell: bash
 
+    env:
+      GOOGLE_APPLICATION_CREDENTIALS: /tmp/service_account_credentials.json
+      GOOGLE_REMOTE_CACHE: https://storage.googleapis.com/reboot-dev-eventuals-remote-cache
+
     steps:
       # Checkout the repository under $GITHUB_WORKSPACE.
       - uses: actions/checkout@v2
         with:
           submodules: "recursive"
+
+      - name: Set up remote cache credentials (1)
+        uses: jsdaniell/create-json@1.1.2
+        with:
+          name: "service_account_credentials.json"
+          json: ${{ secrets.GCP_GITHUB_INFRA_REMOTE_CACHE_CREDENTIALS }}
+
+      - name: Set up remote cache credentials (2)
+        run: mv ./service_account_credentials.json $GOOGLE_APPLICATION_CREDENTIALS
 
       # Install Dazel, so that we use the same build tooling in our Actions as
       # we do on our workstations.
@@ -63,6 +76,8 @@ jobs:
             --spawn_strategy=local \
             -c dbg \
             --strip="never" \
+            --remote_cache=$GOOGLE_REMOTE_CACHE \
+            --google_credentials=$GOOGLE_APPLICATION_CREDENTIALS
             :eventuals
 
       - name: Test

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -24,23 +24,23 @@ jobs:
     strategy:
       matrix:
         include:
-          - os: macos-latest
-            sudo-command: "sudo"
-            # The macos runner doesn't have `docker` installed, so can't run
-            # `dazel`. Fall back to `bazel`.
-            bazel-command: "bazel"
-            bazel-config: ""
+#          - os: macos-latest
+#            sudo-command: "sudo"
+#            # The macos runner doesn't have `docker` installed, so can't run
+#            # `dazel`. Fall back to `bazel`.
+#            bazel-command: "bazel"
+#            bazel-config: ""
           - os: ubuntu-latest
             sudo-command: "sudo"
             bazel-command: "dazel"
             bazel-config: "--config=asan"
-          - os: windows-2019
-            sudo-command: "" # The Windows runner already runs as root.
-            # Our `dazel` container is based on `ubuntu:latest`, which doesn't
-            # support running on the `windows/amd64` platform. Fall back to
-            # `bazel`.
-            bazel-command: "bazel"
-            bazel-config: ""
+#          - os: windows-2019
+#            sudo-command: "" # The Windows runner already runs as root.
+#            # Our `dazel` container is based on `ubuntu:latest`, which doesn't
+#            # support running on the `windows/amd64` platform. Fall back to
+#            # `bazel`.
+#            bazel-command: "bazel"
+#            bazel-config: ""
 
     defaults:
       run:

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -47,7 +47,7 @@ jobs:
         shell: bash
 
     env:
-      GOOGLE_APPLICATION_CREDENTIALS: /tmp/service_account_credentials.json
+      GOOGLE_APPLICATION_CREDENTIALS: service_account_credentials.json
       GOOGLE_REMOTE_CACHE: https://storage.googleapis.com/reboot-dev-eventuals-remote-cache
 
     steps:
@@ -62,8 +62,8 @@ jobs:
           name: "service_account_credentials.json"
           json: ${{ secrets.GCP_GITHUB_INFRA_REMOTE_CACHE_CREDENTIALS }}
 
-      - name: Set up remote cache credentials (2)
-        run: mv ./service_account_credentials.json $GOOGLE_APPLICATION_CREDENTIALS
+#      - name: Set up remote cache credentials (2)
+#        run: mv ./service_account_credentials.json $GOOGLE_APPLICATION_CREDENTIALS
 
       # Install Dazel, so that we use the same build tooling in our Actions as
       # we do on our workstations.
@@ -77,8 +77,8 @@ jobs:
             --spawn_strategy=local \
             -c dbg \
             --strip="never" \
-            --remote_cache=https://storage.googleapis.com/reboot-dev-eventuals-remote-cache \
-            --google_credentials=/tmp/service_account_credentials.json \
+            --remote_cache=$GOOGLE_REMOTE_CACHE \
+            --google_credentials=$GOOGLE_APPLICATION_CREDENTIALS \
             :eventuals
 
       - name: Test

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -10,7 +10,6 @@ on:
   push:
     branches:
       - "main"
-      - "bulat.add-remote-cache"
     paths-ignore:
       - "**.md"
   pull_request:
@@ -56,7 +55,7 @@ jobs:
         with:
           submodules: "recursive"
 
-      - name: Set up remote cache credentials (1)
+      - name: Set up remote cache credentials
         uses: jsdaniell/create-json@1.1.2
         with:
           name: ${{ env.GOOGLE_APPLICATION_CREDENTIALS }}
@@ -91,6 +90,6 @@ jobs:
             --test_arg=--gtest_shuffle \
             --test_arg=--gtest_repeat=100
 
-#      - name: Debug using tmate (if failure)
-#        if: ${{ failure() }}
-#        uses: mxschmitt/action-tmate@v3
+      - name: Debug using tmate (if failure)
+        if: ${{ failure() }}
+        uses: mxschmitt/action-tmate@v3

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -75,6 +75,7 @@ jobs:
             --strip="never" \
             --remote_cache=$GOOGLE_REMOTE_CACHE \
             --google_credentials=$GOOGLE_APPLICATION_CREDENTIALS \
+            --verbose_failures \
             :eventuals
 
       - name: Test

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -77,8 +77,8 @@ jobs:
             --spawn_strategy=local \
             -c dbg \
             --strip="never" \
-            --remote_cache=$GOOGLE_REMOTE_CACHE \
-            --google_credentials=$GOOGLE_APPLICATION_CREDENTIALS
+            --remote_cache=https://storage.googleapis.com/reboot-dev-eventuals-remote-cache \
+            --google_credentials=/tmp/service_account_credentials.json \
             :eventuals
 
       - name: Test
@@ -94,6 +94,6 @@ jobs:
             --test_arg=--gtest_shuffle \
             --test_arg=--gtest_repeat=100
 
-      - name: Debug using tmate (if failure)
-        if: ${{ failure() }}
-        uses: mxschmitt/action-tmate@v3
+#      - name: Debug using tmate (if failure)
+#        if: ${{ failure() }}
+#        uses: mxschmitt/action-tmate@v3


### PR DESCRIPTION
Modified pipeline to use remote cache located in Google Cloud Storage with Google credentials.
Google credentials are stored in GitHub organization secrets.