### PR TITLE
Add explicit `has_value` method

### DIFF
--- a/eventuals/expected.h
+++ b/eventuals/expected.h
@@ -82,7 +82,7 @@ class _Expected {
           int> = 0>
   _Expected(_Expected<T, Errors> that)
     : variant_([&]() {
-        if (that.variant_.index() == 0) {
+        if (that.has_value()) {
           return std::variant<Value_, std::exception_ptr>(
               std::get<0>(std::move(that.variant_)));
         } else {
@@ -131,12 +131,16 @@ class _Expected {
         .template k<Value_>(std::move(k));
   }
 
-  explicit operator bool() const {
+  bool has_value() const {
     return variant_.index() == 0;
   }
 
+  explicit operator bool() const {
+    return has_value();
+  }
+
   Value_* operator->() {
-    if (*this) {
+    if (has_value()) {
       return &std::get<0>(variant_);
     } else {
       std::rethrow_exception(std::get<1>(variant_));
@@ -144,7 +148,7 @@ class _Expected {
   }
 
   Value_& operator*() {
-    if (*this) {
+    if (has_value()) {
       return std::get<0>(variant_);
     } else {
       std::rethrow_exception(std::get<1>(variant_));

--- a/test/expected.cc
+++ b/test/expected.cc
@@ -14,17 +14,17 @@ using eventuals::Unexpected;
 TEST(Expected, Construct) {
   Expected::Of<std::string> s = "hello world";
 
-  ASSERT_TRUE(s);
+  ASSERT_TRUE(s.has_value());
   EXPECT_EQ("hello world", *s);
 
   s = Expected::Of<std::string>(s);
 
-  ASSERT_TRUE(s);
+  ASSERT_TRUE(s.has_value());
   EXPECT_EQ("hello world", *s);
 
   s = Expected::Of<std::string>(std::move(s));
 
-  ASSERT_TRUE(s);
+  ASSERT_TRUE(s.has_value());
   EXPECT_EQ("hello world", *s);
 }
 


### PR DESCRIPTION
This allows for explicit checks of `Expected::Of`s for whether the instance has a value of not instead of relying on the less explicit cast to bool.