### PR TITLE
Update from gRPC 1.40.0 to 1.45.0-pre1

### DIFF
--- a/WORKSPACE.bazel
+++ b/WORKSPACE.bazel
@@ -27,17 +27,11 @@ grpc_extra_deps()
 #   (2) They're only used for tests and we assume those depending on
 #       eventuals don't need to depend on the tests.
 
-load("@io_bazel_rules_python//python:pip.bzl", "pip_import", "pip_repositories")
+load("@rules_python//python:pip.bzl", "pip_install")
 
-pip_import(
+pip_install(
     name = "grpc_python_dependencies",
     requirements = "@com_github_grpc_grpc//:requirements.bazel.txt",
 )
-
-load("@grpc_python_dependencies//:requirements.bzl", "pip_install")
-
-pip_repositories()
-
-pip_install()
 
 ########################################################################

--- a/bazel/deps.bzl
+++ b/bazel/deps.bzl
@@ -1,6 +1,5 @@
 """Dependency specific initialization."""
 
-load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe")
 load("@com_github_3rdparty_bazel_rules_asio//bazel:deps.bzl", asio_deps = "deps")
@@ -86,29 +85,5 @@ def deps(repo_mapping = {}):
     pyprotoc_plugin_deps(
         repo_mapping = repo_mapping,
     )
-
-    # !!! Here be dragons !!!
-    # grpc is currently (2021/09/06) pulling in a version of absl and boringssl
-    # that does not compile on linux with neither gcc (11.1) nor clang (12.0).
-    # Here we are front running the dependency loading of grpc to pull
-    # compatible versions.
-    #
-    # First of absl:
-    if "com_google_absl" not in native.existing_rules():
-        http_archive(
-            name = "com_google_absl",
-            url = "https://github.com/abseil/abseil-cpp/archive/refs/tags/20210324.2.tar.gz",
-            strip_prefix = "abseil-cpp-20210324.2",
-            sha256 = "59b862f50e710277f8ede96f083a5bb8d7c9595376146838b9580be90374ee1f",
-        )
-
-    # and then boringssl
-    if "boringssl" not in native.existing_rules():
-        git_repository(
-            name = "boringssl",
-            commit = "fc44652a42b396e1645d5e72aba053349992136a",
-            remote = "https://boringssl.googlesource.com/boringssl",
-            shallow_since = "1627579704 +0000",
-        )
 
     grpc_deps()

--- a/bazel/repos.bzl
+++ b/bazel/repos.bzl
@@ -61,9 +61,10 @@ def repos(external = True, repo_mapping = {}):
     if "com_github_grpc_grpc" not in native.existing_rules():
         http_archive(
             name = "com_github_grpc_grpc",
-            urls = ["https://github.com/grpc/grpc/archive/v1.40.0.tar.gz"],
-            strip_prefix = "grpc-1.40.0",
-            sha256 = "13e7c6460cd979726e5b3b129bb01c34532f115883ac696a75eb7f1d6a9765ed",
+            # TODO(alexmc): Update to a non-pre-release once it's available.
+            urls = ["https://github.com/grpc/grpc/archive/refs/tags/v1.45.0-pre1.tar.gz"],
+            strip_prefix = "grpc-1.45.0-pre1",
+            sha256 = "747a2b766427c1bc2f6bf3d92d3a182879ebb835321b8e5dc3d36760304c6a8e",
         )
 
     if external:


### PR DESCRIPTION
This pulled in a newer version of rules_python (through an implicit
dependency via gRPC, which I don't like) which required porting off of
the `pip_import` rule which was deprecated in release 0.1.0 in Oct 2020
(!): https://github.com/bazelbuild/rules_python/releases/tag/0.1.0 and
deleted in release 0.6.0 in Jan 2022:
https://github.com/bazelbuild/rules_python/releases/tag/0.6.0.

This removes the need to depend on a 1-year old absl library (!).

It also unbreaks bazel 5.0: fixes https://github.com/3rdparty/eventuals-grpc/issues/65.
