### PR TITLE
Update to bazel 5.0.0

### DIFF
--- a/.bazeliskrc
+++ b/.bazeliskrc
@@ -1,3 +1,1 @@
-# We need this version cause on bazel 5.0.0
-# the build is unsuccessful.
-USE_BAZEL_VERSION=4.2.2
+USE_BAZEL_VERSION=5.0.0


### PR DESCRIPTION
Bazel 5 used to generate build errors on our code:
https://github.com/3rdparty/eventuals-grpc/issues/65

but that was fixed with a newer gRPC release:
https://github.com/3rdparty/eventuals/pull/247
