### PR TITLE
Add `ErrorsFrom` for simple eventuals that just propagate received errors

### DIFF
--- a/eventuals/filter.h
+++ b/eventuals/filter.h
@@ -65,6 +65,9 @@ struct _Filter final {
     template <typename Arg>
     using ValueFrom = Arg;
 
+    template <typename Arg, typename Errors>
+    using ErrorsFrom = Errors;
+
     template <typename Arg, typename K>
     auto k(K k) && {
       return Continuation<K, F_, Arg>(std::move(k), std::move(f_));

--- a/eventuals/range.h
+++ b/eventuals/range.h
@@ -83,6 +83,9 @@ struct _Range final {
     template <typename>
     using ValueFrom = int;
 
+    template <typename Arg, typename Errors>
+    using ErrorsFrom = Errors;
+
     template <typename Arg, typename K>
     auto k(K k) && {
       return Continuation<K, Arg>(std::move(k), from_, to_, step_);

--- a/eventuals/repeat.h
+++ b/eventuals/repeat.h
@@ -67,6 +67,9 @@ struct _Repeat final {
     template <typename Arg>
     using ValueFrom = void;
 
+    template <typename Arg, typename Errors>
+    using ErrorsFrom = Errors;
+
     template <typename Arg, typename K>
     auto k(K k) {
       return Continuation<K>(std::move(k));

--- a/eventuals/take.h
+++ b/eventuals/take.h
@@ -118,6 +118,9 @@ struct _TakeLastN final {
     template <typename Arg>
     using ValueFrom = Arg;
 
+    template <typename Arg, typename Errors>
+    using ErrorsFrom = Errors;
+
     template <typename Arg, typename K>
     auto k(K k) && {
       return Continuation<K, Arg>(std::move(k), std::move(n_));
@@ -186,6 +189,9 @@ struct _TakeRange final {
   struct Composable final {
     template <typename Arg>
     using ValueFrom = Arg;
+
+    template <typename Arg, typename Errors>
+    using ErrorsFrom = Errors;
 
     template <typename Arg, typename K>
     auto k(K k) && {

--- a/eventuals/until.h
+++ b/eventuals/until.h
@@ -84,6 +84,9 @@ struct _Until final {
     template <typename Arg>
     using ValueFrom = Arg;
 
+    template <typename Arg, typename Errors>
+    using ErrorsFrom = Errors;
+
     template <typename Arg, typename K>
     auto k(K k) && {
       return Continuation<K, F_, Arg>(std::move(k), std::move(f_));


### PR DESCRIPTION
Not testable now. Will add tests when other eventual would be up with `ErrorsFrom`.