### PR TITLE
Also use remote cache when we test

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -78,36 +78,28 @@ jobs:
         if: ${{ matrix.os == 'windows-2019' }}
         run: ${{ matrix.sudo-command }} pip3 install wheel
 
-      - name: Build
-        # With the exception of GITHUB_TOKEN, secrets are not passed to the runner
-        # when a workflow is triggered from a forked repository.
+      # With the exception of GITHUB_TOKEN, secrets are not passed to the runner
+      # when a workflow is triggered from a forked repository, and thus we
+      # can only set up a remote cache if this pull request comes from a
+      # non-forked repository.
+      - name: Set Up Remote Cache
         if: github.event.pull_request.head.repo.full_name == '3rdparty/eventuals'
         run: |
-          ${{ matrix.bazel-command }} \
-            ${{ matrix.output-user_root }} \
-            build \
-            ${{ matrix.bazel-config }} \
-            --spawn_strategy=local \
-            -c dbg \
-            --strip="never" \
-            --remote_cache=$GOOGLE_REMOTE_CACHE \
-            --google_credentials=$GOOGLE_APPLICATION_CREDENTIALS \
-            --verbose_failures \
-            ...
+         echo "BAZEL_REMOTE_CACHE=--remote_cache=${{ env.GOOGLE_REMOTE_CACHE }} \
+           --google_credentials=${{ env.GOOGLE_APPLICATION_CREDENTIALS }}" \
+           >> $GITHUB_ENV
 
-      # With the exception of GITHUB_TOKEN, secrets are not passed to the runner
-      # when a workflow is triggered from a forked repository.
-      - name: Build forked
-        if: github.event.pull_request.head.repo.full_name != '3rdparty/eventuals'
+      - name: Build
         run: |
           ${{ matrix.bazel-command }} \
             ${{ matrix.output-user_root }} \
             build \
             ${{ matrix.bazel-config }} \
+            ${{ env.BAZEL_REMOTE_CACHE }} \
+            --verbose_failures \
             --spawn_strategy=local \
             -c dbg \
             --strip="never" \
-            --verbose_failures \
             ...
 
       - name: Test
@@ -117,6 +109,8 @@ jobs:
             test \
             ${{ matrix.bazel-config }} \
             --experimental_ui_max_stdouterr_bytes=-1 \
+            ${{ env.BAZEL_REMOTE_CACHE }} \
+            --verbose_failures \
             --spawn_strategy=local \
             -c dbg \
             --strip="never" \


### PR DESCRIPTION
Seems like we missed using the remote cache for testing which is actually where most of the building takes place (since eventuals is primarily a header library, but even if it was not, we still want to use the cache for building the tests).