### PR TITLE
Parallelize //test:grpc in workflows

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -119,14 +119,14 @@ jobs:
             ${{ env.BAZEL_REMOTE_CACHE }} \
             --verbose_failures \
             --spawn_strategy=local \
+            --runs_per_test=10 \
             -c dbg \
             --strip="never" \
             --test_output=errors \
             test/... \
             --test_arg=--gtest_shuffle \
-            --test_arg=--gtest_repeat=100
+            --test_arg=--gtest_repeat=10
 
       - name: Debug using tmate (if failure)
         if: ${{ failure() }}
         uses: mxschmitt/action-tmate@v3
-        


### PR DESCRIPTION
This increases parallelization of test runs (sequential runs consume
each other's timeouts, whereas parallel tests have independent timeouts)
while still guaranteeing varied coverage of random test seeds.
See discussion on https://github.com/3rdparty/eventuals/issues/271

Fixes https://github.com/3rdparty/eventuals/issues/271.
