### PR TITLE
Increase `//test:grpc`'s timeout

### DIFF
--- a/test/BUILD.bazel
+++ b/test/BUILD.bazel
@@ -129,7 +129,12 @@ cc_binary(
 
 cc_test(
     name = "grpc",
-    timeout = "short",
+    # Our GitHub workflows run this test 100x: this test takes about 1s to run
+    # when compiled with -c dbg (which the workflow does), and 100x 1s = 100s
+    # which requires a moderate timeout.
+    # TODO(alexmc): Parallelize this test or speed it up to shorten this
+    # timeout.
+    timeout = "moderate",
     srcs = [
         "accept.cc",
         "build-and-start.cc",


### PR DESCRIPTION
Fixes https://github.com/3rdparty/eventuals/issues/271, though I added a
`TODO` to find a way to fix this via speedups rather than a longer
timeout.
