### PR TITLE
Shard //test:grpc to fix test timeouts

### DIFF
--- a/test/BUILD.bazel
+++ b/test/BUILD.bazel
@@ -158,6 +158,10 @@ cc_test(
     # link until https://github.com/grpc/grpc/issues/13856 gets
     # resolved.
     linkstatic = True,
+    # This test is fairly fast, but our GitHub Action Runner compiles with
+    # -c dbg --config=asan (~1s per test) and runs it 100x which often hits
+    # the default "short" timeout without sharding.
+    shard_count = 5,
     # TODO(benh): resolve build issues on Windows and then remove
     # these 'target_compatible_with' constraints.
     target_compatible_with = select({


### PR DESCRIPTION
This increases parallelization of test runs (sequential runs consume
each other's timeouts, whereas parallel tests have independent timeouts)
while still guaranteeing varied coverage of random test seeds.
See discussion on https://github.com/3rdparty/eventuals/issues/271

Speeds up tests by 2-5x (2x on average).

TESTED= `dazel test -c dbg --config=asan --spawn_strategy=local --strip="never" //test:grpc --test_arg=--gtest_shuffle --test_arg=--gtest_repeat=100 --runs_per_test=10`

Before:
```
INFO: Build completed, 1 test FAILED, 11 total actions
//test:grpc.   TIMEOUT in 10 out of 10 in 60.1s
  Stats over 10 runs: max = 60.1s, min = 60.1s, avg = 60.1s, dev = 0.0s
```

After:
```
INFO: Build completed successfully, 51 total actions
//test:grpc.   PASSED in 41.1s
  Stats over 50 runs: max = 41.1s, min = 12.9s, avg = 26.6s, dev = 6.8s
```

Fixes https://github.com/3rdparty/eventuals/issues/271.
