### PR TITLE
Fix compilation error due to exception-type-mismatch

### DIFF
--- a/protoc-gen-eventuals/templates/eventuals.cc.j2
+++ b/protoc-gen-eventuals/templates/eventuals.cc.j2
@@ -27,7 +27,7 @@ using eventuals::grpc::Stream;
 using namespace {{ namespaces | join('::') }}::eventuals;
 
 {% for service in services -%}
-Task::Of<void>::Raises<std::exception> {{ service.name }}::TypeErasedService::Serve() {
+Task::Of<void>::Raises<std::runtime_error> {{ service.name }}::TypeErasedService::Serve() {
   return [this]() {
     return DoAll(
 {%- for method in service.methods %}

--- a/protoc-gen-eventuals/templates/eventuals.h.j2
+++ b/protoc-gen-eventuals/templates/eventuals.h.j2
@@ -20,7 +20,7 @@ struct {{ service.name }} {
 
   class TypeErasedService : public ::eventuals::grpc::Service {
    public:
-    ::eventuals::Task::Of<void>::Raises<std::exception> Serve() override;
+    ::eventuals::Task::Of<void>::Raises<std::runtime_error> Serve() override;
 
     char const* name() override {
       return {{ service.name }}::service_full_name();


### PR DESCRIPTION
As reported in https://github.com/3rdparty/eventuals/issues/289 our
generated code fails to compile due to a mismatch between hand-written
code in `server.h` (which uses `std::runtime_error`) and auto-generated
code (which uses `std::exception`).

This PR resolves that conflict in favor of the hand-written code,
changing the generated code to use `std::runtime_error`. It picks this
approach since... I couldn't get the other way 'round to compile! I'd
love to chat with you, @benh, to learn why that is.

In the meantime, this demonstrates at least one possible fix. I've
confirmed that our Respect object store compiles with these latest
fixes, resolving https://github.com/reboot-dev/respect/issues/230.

TESTED: compiled the Respect object store.

Fixes #289 