### PR TITLE
Improve too-constraining static assert.

### DIFF
--- a/eventuals/grpc/server.cc
+++ b/eventuals/grpc/server.cc
@@ -115,7 +115,7 @@ Server::Server(
     serve->service->Register(this);
 
     serve->task.emplace(
-        Task::Of<void>::Raises<std::runtime_error>([service]() {
+        Task::Of<void>::Raises<std::exception>([service]() {
           // Use a separate preemptible scheduler context to serve
           // each service so that we correctly handle any waiting
           // (e.g., on 'Lock' or 'Wait').

--- a/eventuals/grpc/server.h
+++ b/eventuals/grpc/server.h
@@ -51,7 +51,7 @@ class Service {
  public:
   virtual ~Service() = default;
 
-  virtual Task::Of<void>::Raises<std::runtime_error> Serve() = 0;
+  virtual Task::Of<void>::Raises<std::exception> Serve() = 0;
 
   virtual char const* name() = 0;
 
@@ -550,7 +550,7 @@ class Server : public Synchronizable {
   struct Serve {
     Service* service;
     Interrupt interrupt;
-    std::optional<Task::Of<void>::Raises<std::runtime_error>> task;
+    std::optional<Task::Of<void>::Raises<std::exception>> task;
     std::atomic<bool> done = false;
   };
 

--- a/eventuals/task.h
+++ b/eventuals/task.h
@@ -367,7 +367,9 @@ struct _TaskFromToWith final {
       using ErrorsFromE = typename E::template ErrorsFrom<From_, std::tuple<>>;
 
       static_assert(
-          eventuals::tuple_types_subset_v<ErrorsFromE, Errors_>,
+          std::disjunction_v<
+              eventuals::tuple_types_contains<std::exception, Errors_>,
+              eventuals::tuple_types_subset<ErrorsFromE, Errors_>>,
           "Specified errors can't be raised within 'Task'");
 
       static_assert(

--- a/test/helloworld.eventuals.cc
+++ b/test/helloworld.eventuals.cc
@@ -26,7 +26,7 @@ namespace eventuals {
 
 ////////////////////////////////////////////////////////////////////////
 
-Task::Of<void>::Raises<std::runtime_error> Greeter::TypeErasedService::Serve() {
+Task::Of<void>::Raises<std::exception> Greeter::TypeErasedService::Serve() {
   return [this]() {
     return DoAll(
                // SayHello

--- a/test/helloworld.eventuals.h
+++ b/test/helloworld.eventuals.h
@@ -18,7 +18,7 @@ class Greeter {
 
   class TypeErasedService : public ::eventuals::grpc::Service {
    public:
-    ::eventuals::Task::Of<void>::Raises<std::runtime_error> Serve() override;
+    ::eventuals::Task::Of<void>::Raises<std::exception> Serve() override;
 
     char const* name() override {
       return Greeter::service_full_name();


### PR DESCRIPTION
Before this PR the static assert in `task.h` that checks that a given
`Task` only raises the errors specified in its `::Raises` clause didn't
accommodate the possiblity of specifying `::Raises<std::exception>` as
a catch-all.

This PR makes it possible to use that catch-all, allowing us to modify
`server.h` and `server.cc` to match the `std::exception` currently being
raised by generated code.

Fixes https://github.com/3rdparty/eventuals/issues/289

Tested: built `reboot-dev/respect:respect-object-store.tar`.