### PR TITLE
Add basic compilation tests for generated code

### DIFF
--- a/bazel/deps.bzl
+++ b/bazel/deps.bzl
@@ -1,5 +1,6 @@
 """Dependency specific initialization."""
 
+load("@bazel_skylib//:workspace.bzl", "bazel_skylib_workspace")
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe")
 load("@com_github_3rdparty_bazel_rules_asio//bazel:deps.bzl", asio_deps = "deps")
@@ -20,6 +21,8 @@ def deps(repo_mapping = {}):
     asio_deps(
         repo_mapping = repo_mapping,
     )
+
+    bazel_skylib_workspace()
 
     curl_deps(
         repo_mapping = repo_mapping,

--- a/bazel/repos.bzl
+++ b/bazel/repos.bzl
@@ -66,6 +66,16 @@ def repos(external = True, repo_mapping = {}):
             sha256 = "ec19657a677d49af59aa806ec299c070c882986c9fcc022b1c22c2a3caf01bcd",
         )
 
+    maybe(
+        http_archive,
+        name = "bazel_skylib",
+        urls = [
+            "https://mirror.bazel.build/github.com/bazelbuild/bazel-skylib/releases/download/1.2.1/bazel-skylib-1.2.1.tar.gz",
+            "https://github.com/bazelbuild/bazel-skylib/releases/download/1.2.1/bazel-skylib-1.2.1.tar.gz",
+        ],
+        sha256 = "f7be3474d42aae265405a592bb7da8e171919d74c16f082a5457840f06054728",
+    )
+
     if external:
         maybe(
             git_repository,

--- a/test/BUILD.bazel
+++ b/test/BUILD.bazel
@@ -1,5 +1,60 @@
-load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library", "cc_test")
+load("@bazel_skylib//rules:build_test.bzl", "build_test")
+
+# NOTE: instead of 'cc_grpc_library' from '@com_github_grpc_grpc'
+# could also use 'cpp_grpc_library' from '@rules_proto_grpc'.
+load("@com_github_grpc_grpc//bazel:cc_grpc_library.bzl", "cc_grpc_library")
+load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library", "cc_proto_library", "cc_test")
+load("@rules_proto//proto:defs.bzl", "proto_library")
+load("//bazel:cc_eventuals_library.bzl", "cc_eventuals_library")
 load("//bazel:copts.bzl", "copts")
+
+proto_library(
+    name = "sample_service_proto",
+    testonly = True,
+    srcs = [":sample_service.proto"],
+)
+
+cc_proto_library(
+    name = "sample_service_cc_proto",
+    testonly = True,
+    deps = [":sample_service_proto"],
+)
+
+cc_grpc_library(
+    name = "sample_service_grpc",
+    testonly = True,
+    srcs = [":sample_service_proto"],
+    grpc_only = True,
+    deps = [
+        ":sample_service_cc_proto",
+        "@com_github_grpc_grpc//:grpc++",
+    ],
+)
+
+cc_eventuals_library(
+    name = "sample_service_eventuals_generated",
+    testonly = True,
+    srcs = ["sample_service.proto"],
+    deps = [":sample_service_proto"],
+)
+
+cc_library(
+    name = "sample_service_eventuals",
+    testonly = True,
+    srcs = ["sample_service_eventuals_generated"],
+    copts = copts(),
+    deps = [
+        ":sample_service_grpc",
+        "//:grpc",
+    ],
+)
+
+# Make sure that generated eventuals-wrapped service code at leasts builds.
+# TODO(alexmc, benh): verify correctness as well as compilability.
+build_test(
+    name = "sample_service_eventuals_build_test",
+    targets = [":sample_service_eventuals"],
+)
 
 cc_library(
     name = "expect-throw-what",

--- a/test/sample_service.proto
+++ b/test/sample_service.proto
@@ -1,0 +1,11 @@
+syntax = "proto3";
+
+package test;
+
+message Request {}
+
+message Response {}
+
+service SampleService {
+  rpc SampleMethod(Request) returns (Response) {}
+}


### PR DESCRIPTION
Fixes https://github.com/3rdparty/eventuals/issues/291

As expected, this catches when backwards-incompatible code-gen updates
(like https://github.com/reboot-dev/pyprotoc-plugin/commit/ad976383919a1d96e6d1e6a2c86c0ff95623c8ee)
fail to compile. Nice!
