### PR TITLE
Use 'borrowed_callable' to ensure safe use of timers

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -89,6 +89,7 @@ cc_library(
     copts = copts(),
     deps = [
         ":base",
+        "@com_github_3rdparty_stout_borrowed_ptr//:borrowed_ptr",
         "@com_github_chriskohlhoff_asio//:asio",
         "@com_github_libuv_libuv//:libuv",
     ],

--- a/test/timer.cc
+++ b/test/timer.cc
@@ -144,6 +144,12 @@ TEST_F(EventLoopTest, PauseClockInterruptTimer) {
   EventLoop::Default().RunUntil(future);
 
   EXPECT_THROW(future.get(), eventuals::StoppedException);
+
+  // Advance the clock so that we relinquish the borrow on the timer
+  // and it can be destructed.
+  Clock().Advance(std::chrono::seconds(100));
+
+  Clock().Resume();
 }
 
 


### PR DESCRIPTION
@ArthurBandaryk this is what we need to do throughout the code base, let me know if you have any questions!