### PR TITLE
Use typed input for enabling tmate debugging

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -20,8 +20,8 @@ on:
       # When manually running this workflow:
       # https://docs.github.com/en/actions/managing-workflow-runs/manually-running-a-workflow
       debug_enabled:
-        description: 'Run the build with tmate debugging enabled (https://github.com/marketplace/actions/debugging-with-tmate)'
-        required: false
+        description: 'Enable tmate debugging:'
+        type: boolean
         default: false
 
 jobs:


### PR DESCRIPTION
Before this commit we used a string which required users to know they needed to add `true` or `false` and instead a typed input should make this more user friendly.