### PR TITLE
Remove useless colon

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -20,7 +20,7 @@ on:
       # When manually running this workflow:
       # https://docs.github.com/en/actions/managing-workflow-runs/manually-running-a-workflow
       debug_enabled:
-        description: 'Enable tmate debugging:'
+        description: 'Enable tmate debugging'
         type: boolean
         default: false
 


### PR DESCRIPTION
GitHub renders the checkbox to the left of the description text which makes the colon useless. But more importantly, we probably shouldn't rely on the rendering in case they change it in the future!