### PR TITLE
Remove unnecessary DAZEL_VOLUMES

### DIFF
--- a/.dazelrc
+++ b/.dazelrc
@@ -12,7 +12,6 @@ import os.path
 DAZEL_BAZEL_USER_OUTPUT_ROOT = os.path.expanduser("~/.cache/dazel/tests")
 
 DAZEL_DOCKERFILE = "Dockerfile.dazel"
-DAZEL_VOLUMES = ["/var/run/docker.sock:/var/run/docker.sock"]
 
 # Use a unique Dazel image and instance name so it doesn't conflict with other
 # Dazel instances in other repos.


### PR DESCRIPTION
Perhaps we'll need to add this in the future if/when we create images and specifically want to use a Docker that is outside of the running Dazel container, but for now we're removing this so that it doesn't cause an unexpected bug or send people in the wrong direction when debugging.