### PR TITLE
Use callables instead of eventuals for 'If.yes()' and 'If.no()'

### DIFF
--- a/eventuals/generator.h
+++ b/eventuals/generator.h
@@ -352,18 +352,18 @@ struct _Generator final {
       : args_(std::tuple<Args_...>(std::move(args)...)) {
       static_assert(
           std::tuple_size<decltype(args_)>{} > 0 || std::is_invocable_v<F>,
-          "'Generator' expects a callable that "
+          "'Generator' expects a callable (e.g., a lambda) that "
           "takes no arguments");
 
       static_assert(
           std::tuple_size<decltype(args_)>{}
               || std::is_invocable_v<F, Args_...>,
-          "'Generator' expects a callable that "
+          "'Generator' expects a callable (e.g., a lambda) that "
           "takes the arguments specified");
 
       static_assert(
           sizeof(f) <= sizeof(void*),
-          "'Generator' expects a callable that "
+          "'Generator' expects a callable (e.g., a lambda) that "
           "can be captured in a 'Callback'");
 
       using E = decltype(std::apply(f, args_));

--- a/eventuals/if.h
+++ b/eventuals/if.h
@@ -144,14 +144,6 @@ struct _If final {
       static_assert(!IsUndefined<YesE_>::value, "Missing 'yes'");
       static_assert(!IsUndefined<NoE_>::value, "Missing 'no'");
 
-      static_assert(
-          HasValueFrom<YesE_>::value,
-          "'If' expects an eventual for 'yes'");
-
-      static_assert(
-          HasValueFrom<NoE_>::value,
-          "'If' expects an eventual for 'no'");
-
       return Continuation<K, YesE_, NoE_>(
           std::move(k),
           condition_,
@@ -159,16 +151,26 @@ struct _If final {
           std::move(no_));
     }
 
-    template <typename YesE>
-    auto yes(YesE yes) && {
+    template <typename YesF>
+    auto yes(YesF yes) && {
       static_assert(IsUndefined<YesE_>::value, "Duplicate 'yes'");
-      return create(condition_, std::move(yes), std::move(no_));
+
+      static_assert(
+          !HasValueFrom<YesF>::value,
+          "'If().yes()' expects a callable (e.g., a lambda) not an eventual");
+
+      return create(condition_, Then(std::move(yes)), std::move(no_));
     }
 
-    template <typename NoE>
-    auto no(NoE no) && {
+    template <typename NoF>
+    auto no(NoF no) && {
       static_assert(IsUndefined<NoE_>::value, "Duplicate 'no'");
-      return create(condition_, std::move(yes_), std::move(no));
+
+      static_assert(
+          !HasValueFrom<NoF>::value,
+          "'If().no()' expects a callable (e.g., a lambda) not an eventual");
+
+      return create(condition_, std::move(yes_), Then(std::move(no)));
     }
 
     bool condition_;

--- a/eventuals/map.h
+++ b/eventuals/map.h
@@ -143,7 +143,7 @@ template <typename F>
 auto Map(F f) {
   static_assert(
       !HasValueFrom<F>::value,
-      "'Map' expects a callable not an eventual");
+      "'Map' expects a callable (e.g., a lambda) not an eventual");
 
   auto e = Then(std::move(f));
 

--- a/eventuals/repeat.h
+++ b/eventuals/repeat.h
@@ -83,7 +83,7 @@ template <typename F>
 auto Repeat(F f) {
   static_assert(
       !HasValueFrom<F>::value,
-      "'Repeat' expects a callable not an eventual");
+      "'Repeat' expects a callable (e.g., a lambda) not an eventual");
 
   return _Repeat::Composable{} | Map(std::move(f));
 }

--- a/eventuals/task.h
+++ b/eventuals/task.h
@@ -325,17 +325,17 @@ struct _TaskFromToWith final {
       : args_(std::tuple<Args_...>(std::move(args)...)) {
       static_assert(
           std::tuple_size<decltype(args_)>{} > 0 || std::is_invocable_v<F>,
-          "'Task' expects a callable that takes no arguments");
+          "'Task' expects a callable (e.g., a lambda) that takes no arguments");
 
       static_assert(
           std::tuple_size<decltype(args_)>{}
               || std::is_invocable_v<F, Args_...>,
-          "'Task' expects a callable that "
+          "'Task' expects a callable (e.g., a lambda) that "
           "takes the arguments specified");
 
       static_assert(
           sizeof(f) <= sizeof(void*),
-          "'Task' expects a callable that "
+          "'Task' expects a callable (e.g., a lambda) that "
           "can be captured in a 'Callback'");
 
       using E = decltype(std::apply(f, args_));

--- a/eventuals/transformer.h
+++ b/eventuals/transformer.h
@@ -259,19 +259,20 @@ struct _Transformer final {
     Composable(F f) {
       static_assert(
           std::is_invocable_v<F>,
-          "'Transformer' expects a callable that "
+          "'Transformer' expects a callable (e.g., a lambda) that "
           "takes no arguments");
 
       static_assert(
           sizeof(f) <= sizeof(void*),
-          "'Transformer' expects a callable that "
+          "'Transformer' expects a callable (e.g., a lambda) that "
           "can be captured in a 'Callback'");
 
       using E = decltype(f());
 
       static_assert(
           HasValueFrom<E>::value,
-          "'Transformer' expects a callable that returns an eventual");
+          "'Transformer' expects a callable (e.g., a lambda) that "
+          "returns an eventual");
 
       using ErrorsFromE = typename E::template ErrorsFrom<From_, std::tuple<>>;
 

--- a/test/lock.cc
+++ b/test/lock.cc
@@ -314,12 +314,14 @@ TEST(LockTest, ConditionVariable) {
       return Synchronized(Then([this, id]() {
         auto iterator = condition_variables_.find(id);
         return If(iterator == condition_variables_.end())
-            .yes(Just(false))
-            .no(Then([iterator]() {
+            .yes([]() {
+              return false;
+            })
+            .no([iterator]() {
               auto& condition_variable = iterator->second;
               condition_variable.Notify();
               return true;
-            }));
+            });
       }));
     }
 
@@ -327,12 +329,14 @@ TEST(LockTest, ConditionVariable) {
       return Synchronized(Then([this, id]() {
         auto iterator = condition_variables_.find(id);
         return If(iterator == condition_variables_.end())
-            .yes(Just(false))
-            .no(Then([iterator]() {
+            .yes([]() {
+              return false;
+            })
+            .no([iterator]() {
               auto& condition_variable = iterator->second;
               condition_variable.NotifyAll();
               return true;
-            }));
+            });
       }));
     }
 


### PR DESCRIPTION
Because most folks are not as used to expression based langauges they
run into issues where they end up doing things in the same eventuals
pipeline expression that they weren't expecting because they were
thinking like it was multiple statements. This is true of 'If.yes()'
and 'If.no()'. By making these take callables (e.g., a lambda) instead
then they are forced to treat the bodies of each not as expressions
and thus will be required to think (a little more) about how to
'std::move()' or copy values.