### PR TITLE
Compile with clang by default

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -6,13 +6,20 @@ build --enable_platform_specific_config
 # Verbose failure logs when something goes wrong.
 build --verbose_failures
 
+# Build with clang (rather than the default of gcc) since clang compiles
+# templates faster and produces better error messages.
+# Prefer repo_env over action_env to avoid invalidating the action graph:
+# https://github.com/bazelbuild/bazel/issues/8074
+build --repo_env=CC=clang
+
 # Use Clang as a default compiler on Windows.
-# TODO: use Clang as a default compiler on every platform.
+# TODO(xander): Does repo_env above cover the windows case?
 build:windows --compiler="clang-cl"
 
-# Compiler options.
-build:gcc --action_env=CC=gcc
-build:clang --action_env=CC=clang
+# Make it easy to use gcc.
+# Prefer repo_env over action_env to avoid invalidating the action graph:
+# https://github.com/bazelbuild/bazel/issues/8074
+build:gcc --repo_env=CC=gcc
 
 # Build eventuals in C++17 mode.
 build:linux --cxxopt=-std=c++17

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -116,7 +116,6 @@ jobs:
             ${{ matrix.bazel-config }} \
             ${{ env.BAZEL_REMOTE_CACHE }} \
             --verbose_failures \
-            --spawn_strategy=local \
             -c dbg \
             --strip="never" \
             ...
@@ -130,7 +129,6 @@ jobs:
             --experimental_ui_max_stdouterr_bytes=-1 \
             ${{ env.BAZEL_REMOTE_CACHE }} \
             --verbose_failures \
-            --spawn_strategy=local \
             -c dbg \
             --strip="never" \
             --test_output=errors \


### PR DESCRIPTION
This should speed up template compilation times and improve
https://github.com/3rdparty/eventuals/issues/275.

This also ensures that clang is used on all platforms. Before this PR,
our CI servers were building with gcc.
