### PR TITLE
Prefer explicit typename arg names

### DIFF
--- a/eventuals/eventual.h
+++ b/eventuals/eventual.h
@@ -181,7 +181,7 @@ struct _Eventual {
       typename Value_,
       typename Errors_ = std::tuple<>>
   struct Builder final {
-    template <typename>
+    template <typename Arg>
     using ValueFrom = Value_;
 
     template <typename Arg, typename Errors>


### PR DESCRIPTION
Explicit names are more self-documenting than omitting unused template
argument names.
