### PR TITLE
Use standard C++ to run subprocesses: avoid posix

### DIFF
--- a/test/grpc/BUILD.bazel
+++ b/test/grpc/BUILD.bazel
@@ -1,5 +1,10 @@
-load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_test")
+load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library", "cc_test")
 load("//bazel:copts.bzl", "copts")
+
+cc_library(
+    name = "death-constants",
+    hdrs = ["death-constants.h"],
+)
 
 cc_binary(
     name = "death-client",
@@ -8,6 +13,7 @@ cc_binary(
     ],
     copts = copts(),
     deps = [
+        ":death-constants",
         "//eventuals/grpc",
         "@com_github_grpc_grpc//examples/protos:helloworld_cc_grpc",
     ],
@@ -20,6 +26,7 @@ cc_binary(
     ],
     copts = copts(),
     deps = [
+        ":death-constants",
         "//eventuals/grpc",
         "@com_github_grpc_grpc//examples/protos:helloworld_cc_grpc",
     ],
@@ -28,19 +35,27 @@ cc_binary(
 cc_test(
     name = "grpc",
     timeout = "short",
-    srcs = glob(
-        # Include all test sources...
-        [
-            "*.cc",
-            "*.h",
-        ],
-        # Except files that implement the death-client and death-server
-        # binaries.
-        exclude = [
-            "death-client.cc",
-            "death-server.cc",
-        ],
-    ),
+    # TODO(alexmc): Some of these filenames end with "-test" and others don't.
+    # Rename things for consistency.
+    srcs = [
+        "accept.cc",
+        "build-and-start.cc",
+        "cancelled-by-client.cc",
+        "cancelled-by-server.cc",
+        "client-death-test.cc",
+        "deadline.cc",
+        "greeter-server.cc",
+        "helloworld.eventuals.cc",
+        "helloworld.eventuals.h",
+        "main.cc",
+        "multiple-hosts.cc",
+        "server-death-test.cc",
+        "server-unavailable.cc",
+        "streaming.cc",
+        "test.h",
+        "unary.cc",
+        "unimplemented.cc",
+    ],
     copts = copts(),
     data = [
         ":death-client",
@@ -58,6 +73,7 @@ cc_test(
         "//conditions:default": ["@platforms//:incompatible"],
     }),
     deps = [
+        ":death-constants",
         "//eventuals/grpc",
         "//test:expect-throw-what",
         "@bazel_tools//tools/cpp/runfiles",

--- a/test/grpc/client-death-test.cc
+++ b/test/grpc/client-death-test.cc
@@ -1,3 +1,7 @@
+#include <sys/wait.h>
+
+#include <cstdlib>
+
 #include "eventuals/grpc/server.h"
 #include "eventuals/head.h"
 #include "eventuals/let.h"
@@ -5,6 +9,7 @@
 #include "eventuals/then.h"
 #include "examples/protos/helloworld.grpc.pb.h"
 #include "gtest/gtest.h"
+#include "test/grpc/death-constants.h"
 #include "test/grpc/test.h"
 
 using helloworld::Greeter;
@@ -19,79 +24,10 @@ using eventuals::Then;
 using eventuals::grpc::Server;
 using eventuals::grpc::ServerBuilder;
 
+// Tests that servers correctly handle clients that disconnect before sending a
+// request.
 TEST_F(EventualsGrpcTest, ClientDeathTest) {
-  // NOTE: need pipes so that (1) the client can tell us when it's
-  // forked so we know we can start the server because we can't call
-  // into grpc before we've forked (see
-  // https://github.com/grpc/grpc/issues/14055) and (2) the server can
-  // send the client it's port.
-  struct {
-    int fork[2]; // 'fork[0]' is for reading, 'fork[1]' for writing.
-    int port[2]; // 'port[0]' is for reading, 'port[1]' for writing.
-  } pipes;
-
-  ASSERT_NE(-1, pipe(pipes.fork));
-  ASSERT_NE(-1, pipe(pipes.port));
-
-  auto WaitForFork = [&]() {
-    int _;
-    CHECK_GT(read(pipes.fork[0], &_, sizeof(int)), 0);
-  };
-
-  auto SendPort = [&](int port) {
-    CHECK_GT(write(pipes.port[1], &port, sizeof(port)), 0);
-  };
-
-  // We use a thread to fork/exec the 'death-client' so that we can
-  // simultaneously run and wait for the client to die while also
-  // running the server.
-  std::thread thread([&]() {
-    std::string path = GetRunfilePathFor("death-client").string();
-
-    std::string pipe_fork = std::to_string(pipes.fork[1]);
-    std::string pipe_port = std::to_string(pipes.port[0]);
-
-    // NOTE: doing a 'fork()' when a parent has multiple threads is
-    // wrought with potential issues because the child only gets a
-    // single one of those threads (the one that called 'fork()') so
-    // we ensure here that there is only the single extra thread.
-    ASSERT_EQ(GetThreadCount(), 2);
-
-    ASSERT_DEATH(
-        [&]() {
-          // Conventional wisdom is to do the least amount possible
-          // after a 'fork()', ideally just an 'exec*()', and that's
-          // what we're doing because when we tried to do more the
-          // tests were flaky likely do to some library that doesn't
-          // properly work after doing a 'fork()'.
-          execl(
-              path.c_str(),
-              path.c_str(),
-              pipe_fork.c_str(),
-              pipe_port.c_str(),
-              nullptr);
-
-          // NOTE: if 'execve()' failed then this lamdba will return
-          // and gtest will see consider this "death" to be a failure.
-        }(),
-        // NOTE: to avoid false positives we check for a death with
-        // the string 'connected' printed to stderr.
-        "connected");
-  });
-
-  // NOTE: we detach the thread so that there isn't a race with the
-  // thread completing and attempting to run it's destructor which
-  // will call 'std::terminate()' if we haven't yet called
-  // 'join()'. We know it's safe to detach because the thread (which
-  // acts as the parent process for the client) can destruct itself
-  // whenever it wants because it doesn't depend on anything from the
-  // test which might have been destructed before it destructs.
-  thread.detach();
-
-  // NOTE: need to wait to call into gRPC till _after_ we've forked
-  // (see comment at top of test for more details).
-  WaitForFork();
-
+  // Start a server that will handle requests.
   ServerBuilder builder;
 
   int port = 0;
@@ -121,14 +57,16 @@ TEST_F(EventualsGrpcTest, ClientDeathTest) {
 
   k.Start();
 
-  // NOTE: sending this _after_ we start the eventual so that we're
-  // ready to accept clients!
-  SendPort(port);
+  // Now that the server has started and is ready to accept clients,
+  // start the client. It will connect to the server, start a gRPC call, then
+  // exit before sending a request.
+  const std::string path = GetRunfilePathFor("death-client").string();
+  const std::string command = path + " " + std::to_string(port);
+  // Block on the client until it returns a known return value.
+  const int result = std::system(command.c_str());
+  // Issue(#329): WEXITSTATUS is Posix-specific. Figure out the correct way
+  // to get the application's return code on windows.
+  EXPECT_EQ(eventuals::grpc::kProcessIntentionalExitCode, WEXITSTATUS(result));
 
   EXPECT_TRUE(cancelled.get());
-
-  close(pipes.fork[0]);
-  close(pipes.fork[1]);
-  close(pipes.port[0]);
-  close(pipes.port[1]);
 }

--- a/test/grpc/death-client.cc
+++ b/test/grpc/death-client.cc
@@ -2,6 +2,7 @@
 #include "eventuals/terminal.h"
 #include "eventuals/then.h"
 #include "examples/protos/helloworld.grpc.pb.h"
+#include "test/grpc/death-constants.h"
 
 using helloworld::Greeter;
 using helloworld::HelloReply;
@@ -9,50 +10,12 @@ using helloworld::HelloRequest;
 
 using stout::Borrowable;
 
-using eventuals::Eventual;
-using eventuals::Terminate;
 using eventuals::Then;
 
 using eventuals::grpc::Client;
 using eventuals::grpc::CompletionPool;
 
-// Should only be run from tests!
-//
-// Expects two arguments.
-//
-// Expects 'argv[1]' to be a string representing the file descriptor
-// that this process has inherited from its parent (the test) that can
-// be used to indicate that forking has completed and the test can
-// continue.
-//
-// Expects 'argv[2]' to be a string representing the file descriptor
-// that this process has inherited from its parent (the test) that can
-// be used to read the bound port of the gRPC server to connect to.
-//
-// See 'client-death-test.cc' for more details.
-int main(int argc, char** argv) {
-  // TODO(benh): use stout-flags!
-  CHECK_EQ(argc, 3)
-      << "expecting 'pipe_fork' and 'pipe_port' to be passed as arguments";
-
-  int pipe_fork = atoi(argv[1]);
-  int pipe_port = atoi(argv[2]);
-
-  auto NotifyForked = [&]() {
-    int one = 1;
-    CHECK_GT(write(pipe_fork, &one, sizeof(int)), 0);
-  };
-
-  auto WaitForPort = [&]() {
-    int port;
-    CHECK_GT(read(pipe_port, &port, sizeof(int)), 0);
-    return port;
-  };
-
-  NotifyForked();
-
-  int port = WaitForPort();
-
+void RunClient(const int port) {
   Borrowable<CompletionPool> pool;
 
   Client client(
@@ -63,15 +26,26 @@ int main(int argc, char** argv) {
   auto call = [&]() {
     return client.Call<Greeter, HelloRequest, HelloReply>("SayHello")
         | Then([](auto&& call) {
-             // NOTE: to avoid false positives with, for example, one
-             // of the 'CHECK()'s failing above, the 'ClientDeathTest'
-             // expects the string 'connected' to be written to stderr.
-             std::cerr << "connected" << std::endl;
-             exit(1);
+             exit(eventuals::grpc::kProcessIntentionalExitCode);
            });
   };
 
   *call();
+}
 
+// Should only be run from tests!
+//
+// Expects one argument.
+//
+// Expects 'argv[1]' to be an integer representing the port number that should
+// be used to connect to a gRPC server.
+// See 'client-death-test.cc' for more details.
+int main(int argc, char** argv) {
+  // TODO(benh): use stout-flags!
+  CHECK_EQ(argc, 2) << "expecting 'port' to be passed as an argument";
+
+  int port = atoi(argv[1]);
+
+  RunClient(port);
   return 0;
 }

--- a/test/grpc/death-constants.h
+++ b/test/grpc/death-constants.h
@@ -1,0 +1,10 @@
+// Shared constants used by tests that run binaries that intentionally die.
+
+namespace eventuals::grpc {
+// The exit code issued by a process when dying intentionally. The code number
+// is an arbitrary value that is unlikely to be produced by any other type of
+// unexpected failure (e.g. a CHECK failure). This lets us be confident that
+// tests that run binaries that die with this exit code are dying in an
+// expected way and location.
+constexpr int kProcessIntentionalExitCode = 17;
+} // namespace eventuals::grpc

--- a/test/grpc/server-death-test.cc
+++ b/test/grpc/server-death-test.cc
@@ -1,4 +1,8 @@
+#include <sys/wait.h>
+
+#include <cstdlib>
 #include <filesystem>
+#include <thread>
 
 #include "eventuals/finally.h"
 #include "eventuals/grpc/client.h"
@@ -8,6 +12,7 @@
 #include "eventuals/then.h"
 #include "examples/protos/helloworld.grpc.pb.h"
 #include "gtest/gtest.h"
+#include "test/grpc/death-constants.h"
 #include "test/grpc/test.h"
 
 using helloworld::Greeter;
@@ -26,6 +31,8 @@ using eventuals::grpc::CompletionPool;
 using eventuals::grpc::Server;
 using eventuals::grpc::ServerBuilder;
 
+// Tests that the client receives a ::grpc::UNAVAILABLE status if the server
+// dies without cleanly calling call.Finish().
 TEST_F(EventualsGrpcTest, ServerDeathTest) {
   // NOTE: need pipes to get the server's port, this also helps
   // synchronize when the server is ready to have the client connect.
@@ -39,45 +46,20 @@ TEST_F(EventualsGrpcTest, ServerDeathTest) {
     return port;
   };
 
-  // We use a thread to fork/exec the 'death-server' so that we can
-  // simultaneously run and wait for the server to die while also
-  // running the client.
+  // Launch the server before creating the client. Run the server in a
+  // subprocess so that it can run in parallel with this test.
   std::thread thread([&]() {
-    std::string path = GetRunfilePathFor("death-server").string();
-
-    std::string pipe = std::to_string(pipefds[1]);
-
-    // NOTE: doing a 'fork()' when a parent has multiple threads is
-    // wrought with potential issues because the child only gets a
-    // single one of those threads (the one that called 'fork()') so
-    // we ensure here that there is only the single extra thread.
-    ASSERT_EQ(GetThreadCount(), 2);
-
-    ASSERT_DEATH(
-        [&]() {
-          // Conventional wisdom is to do the least amount possible
-          // after a 'fork()', ideally just an 'exec*()', and that's
-          // what we're doing because when we tried to do more the
-          // tests were flaky likely do to some library that doesn't
-          // properly work after doing a 'fork()'.
-          execl(path.c_str(), path.c_str(), pipe.c_str(), nullptr);
-
-          // NOTE: if 'execve()' failed then this lamdba will return
-          // and gtest will see consider this "death" to be a failure.
-        }(),
-        // NOTE: to avoid false positives we check for a death with
-        // the string 'accepted' printed to stderr.
-        "accepted");
+    const std::string path = GetRunfilePathFor("death-server").string();
+    const std::string pipe = std::to_string(pipefds[1]);
+    const std::string command = path + " " + pipe;
+    // Block on the server until it returns a known return value.
+    const int result = std::system(command.c_str());
+    // Issue(#329): WEXITSTATUS is Posix-specific. Figure out the correct way
+    // to get the application's return code on windows.
+    EXPECT_EQ(
+        eventuals::grpc::kProcessIntentionalExitCode,
+        WEXITSTATUS(result));
   });
-
-  // NOTE: we detach the thread so that there isn't a race with the
-  // thread completing and attempting to run it's destructor which
-  // will call 'std::terminate()' if we haven't yet called
-  // 'join()'. We know it's safe to detach because the thread (which
-  // acts as the parent process for the server) can destruct itself
-  // whenever it wants because it doesn't depend on anything from the
-  // test which might have been destructed before it destructs.
-  thread.detach();
 
   int port = WaitForPort();
 
@@ -103,7 +85,8 @@ TEST_F(EventualsGrpcTest, ServerDeathTest) {
 
   const ::grpc::Status status = *call();
 
-  EXPECT_EQ(grpc::UNAVAILABLE, status.error_code());
+  EXPECT_EQ(::grpc::UNAVAILABLE, status.error_code());
+  thread.join();
 
   close(pipefds[0]);
   close(pipefds[1]);


### PR DESCRIPTION
Use cross-platform standard C++ to run subprocesses. This is an
incremental fix for building and running tests on windows. It also
avoids warnings emitted by `ASSERT_DEATH` caused by `fork()`-ing from a
multithreaded process.

Fixes #337.
