### PR TITLE
Introduce an 'Executor' for "fire and forget" tasks

### DIFF
--- a/eventuals/BUILD.bazel
+++ b/eventuals/BUILD.bazel
@@ -19,6 +19,7 @@ cc_library(
         "conditional.h",
         "do-all.h",
         "eventual.h",
+        "executor.h",
         "expected.h",
         "filter.h",
         "finally.h",

--- a/eventuals/concurrent.h
+++ b/eventuals/concurrent.h
@@ -727,6 +727,10 @@ struct _Concurrent final {
 
     template <typename Arg, typename K>
     auto k(K k) && {
+      static_assert(
+          !std::is_void_v<ValueFrom<Arg>>,
+          "'Concurrent' does not (yet) support 'void' eventual values");
+
       return Continuation<K, F_, Arg>(std::move(k), std::move(f_));
     }
 

--- a/eventuals/executor.h
+++ b/eventuals/executor.h
@@ -1,0 +1,119 @@
+#pragma once
+
+#include "eventuals/catch.h"
+#include "eventuals/concurrent.h"
+#include "eventuals/eventual.h"
+#include "eventuals/interrupt.h"
+#include "eventuals/just.h"
+#include "eventuals/lock.h"
+#include "eventuals/loop.h"
+#include "eventuals/map.h"
+#include "eventuals/pipe.h"
+#include "eventuals/task.h"
+#include "eventuals/type-check.h"
+#include "stout/borrowable.h"
+
+////////////////////////////////////////////////////////////////////////
+
+namespace eventuals {
+
+////////////////////////////////////////////////////////////////////////
+
+// Helper for running "fire and forget" eventuals. The eventual you
+// submit _should not_ be terminated, but you can still determine when
+// your eventuals have completed by composing with a 'Finally()' or a
+// raw 'Eventual()` that handles each possibility.
+template <typename E_>
+class Executor final
+  : public Synchronizable,
+    public stout::enable_borrowable_from_this<Executor<E_>> {
+ public:
+  static_assert(
+      HasValueFrom<E_>::value,
+      "'Executor' expects an eventual type to execute");
+
+  Executor(std::string&& name)
+    : name_(name),
+      wait_until_finished_(&lock()),
+      executor_(this->Borrow([this]() {
+        return pipe_.Read()
+            | Concurrent([this]() {
+                 return Map([this](E_ e) {
+                   return std::move(e)
+                       // NOTE: returning 'std::monostate' since
+                       // 'Concurrent' does not yet support 'void'.
+                       | Just(std::monostate{})
+                       | Catch()
+                             .raised<std::exception>(
+                                 [this](std::exception&& e) {
+                                   EVENTUALS_LOG(1)
+                                       << "Executor '" << name_
+                                       << "' caught: " << e.what();
+                                   return std::monostate{};
+                                 });
+                 });
+               })
+            | Loop()
+            | Synchronized(
+                   Eventual<void>()
+                       .start([this](auto& k) {
+                         finished_ = true;
+                         wait_until_finished_.Notify();
+                         k.Start();
+                       })
+                       .fail([this](auto& k, auto&&...) {
+                         finished_ = true;
+                         wait_until_finished_.Notify();
+                         k.Start();
+                       })
+                       .stop([this](auto& k) {
+                         finished_ = true;
+                         wait_until_finished_.Notify();
+                         k.Start();
+                       }));
+      })) {
+    // Start the executor task!
+    executor_.Start(
+        interrupt_,
+        []() {},
+        [](std::exception_ptr) { LOG(FATAL) << "Unreachable"; },
+        []() { LOG(FATAL) << "Unreachable"; });
+  }
+
+  auto Submit(E_ e) {
+    return TypeCheck<void>(
+        pipe_.Write(std::move(e)));
+  }
+
+  auto Shutdown() {
+    return TypeCheck<void>(
+        pipe_.Close());
+  }
+
+  auto InterruptAndShutdown() {
+    interrupt_.Trigger();
+    return Shutdown();
+  }
+
+  auto Wait() {
+    return TypeCheck<void>(
+        Synchronized(
+            wait_until_finished_.Wait(this->Borrow([this]() {
+              return /* wait = */ !finished_;
+            }))));
+  }
+
+ private:
+  std::string name_;
+  ConditionVariable wait_until_finished_;
+  Task::Of<void> executor_;
+  class Interrupt interrupt_;
+  Pipe<E_> pipe_;
+  bool finished_ = false;
+};
+
+////////////////////////////////////////////////////////////////////////
+
+} // namespace eventuals
+
+////////////////////////////////////////////////////////////////////////

--- a/eventuals/just.h
+++ b/eventuals/just.h
@@ -10,7 +10,7 @@ namespace eventuals {
 
 template <typename T>
 auto Just(T t) {
-  return Eventual<T>([t = std::move(t)](auto& k, auto&&...) {
+  return Eventual<T>([t = std::move(t)](auto& k, auto&&...) mutable {
     k.Start(std::move(t));
   });
 }

--- a/eventuals/pipe.h
+++ b/eventuals/pipe.h
@@ -3,6 +3,7 @@
 #include <deque>
 
 #include "eventuals/callback.h"
+#include "eventuals/just.h"
 #include "eventuals/lock.h"
 #include "eventuals/map.h"
 #include "eventuals/repeat.h"
@@ -55,7 +56,9 @@ class Pipe final : public Synchronizable {
            })
         | Map([](auto&& value) {
              CHECK(value);
-             return std::move(*value);
+             // NOTE: need to use 'Just' here in case 'T' is an
+             // eventual otherwise we'll try and compose with it here!
+             return Just(std::move(*value));
            });
   }
 

--- a/eventuals/task.h
+++ b/eventuals/task.h
@@ -353,6 +353,16 @@ struct _TaskFromToWith final {
 
       using E = decltype(std::apply(f, args_));
 
+      static_assert(
+          std::is_void_v<E> || HasValueFrom<E>::value,
+          "'Task' expects a callable (e.g., a lambda) that "
+          "returns an eventual but you're returning a value");
+
+      static_assert(
+          !std::is_void_v<E>,
+          "'Task' expects a callable (e.g., a lambda) that "
+          "returns an eventual but you're not returning anything");
+
       using Value = typename E::template ValueFrom<From_>;
 
       using ErrorsFromE = typename E::template ErrorsFrom<From_, std::tuple<>>;

--- a/eventuals/transformer.h
+++ b/eventuals/transformer.h
@@ -270,9 +270,14 @@ struct _Transformer final {
       using E = decltype(f());
 
       static_assert(
-          HasValueFrom<E>::value,
+          std::is_void_v<E> || HasValueFrom<E>::value,
           "'Transformer' expects a callable (e.g., a lambda) that "
-          "returns an eventual");
+          "returns an eventual but you're returning a value");
+
+      static_assert(
+          !std::is_void_v<E>,
+          "'Transformer' expects a callable (e.g., a lambda) that "
+          "returns an eventual but you're not returning anything");
 
       using ErrorsFromE = typename E::template ErrorsFrom<From_, std::tuple<>>;
 

--- a/test/BUILD.bazel
+++ b/test/BUILD.bazel
@@ -66,6 +66,7 @@ cc_test(
         "do-all.cc",
         "event-loop-test.h",
         "eventual.cc",
+        "executor.cc",
         "expected.cc",
         "filesystem.cc",
         "filter.cc",

--- a/test/executor.cc
+++ b/test/executor.cc
@@ -1,0 +1,73 @@
+#include "eventuals/executor.h"
+
+#include "eventuals/eventual.h"
+#include "eventuals/just.h"
+#include "eventuals/task.h"
+#include "eventuals/terminal.h"
+#include "eventuals/then.h"
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+
+using eventuals::Eventual;
+using eventuals::Executor;
+using eventuals::Interrupt;
+using eventuals::Just;
+using eventuals::Task;
+using eventuals::Then;
+
+TEST(ExecutorTest, Succeed) {
+  bool executed = false;
+
+  Executor<Task::Of<void>> executor("executor");
+
+  auto e = [&]() {
+    return executor.Submit(
+               Task::Of<void>(
+                   [&]() {
+                     executed = true;
+                     return Just();
+                   }))
+        | Then([&]() {
+             return executor.Shutdown();
+           })
+        | Then([&]() {
+             return executor.Wait();
+           });
+  };
+
+  *e();
+
+  EXPECT_TRUE(executed);
+}
+
+
+TEST(ExecutorTest, Interrupt) {
+  bool interrupted = false;
+
+  Executor<Task::Of<void>> executor("executor");
+
+  auto e = [&]() {
+    return executor.Submit(
+               Task::Of<void>(
+                   [&]() {
+                     return Eventual<void>()
+                         .interruptible()
+                         .start([&](auto& k, Interrupt::Handler& handler) {
+                           handler.Install([&]() {
+                             interrupted = true;
+                             k.Stop();
+                           });
+                         });
+                   }))
+        | Then([&]() {
+             return executor.InterruptAndShutdown();
+           })
+        | Then([&]() {
+             return executor.Wait();
+           });
+  };
+
+  *e();
+
+  EXPECT_TRUE(interrupted);
+}


### PR DESCRIPTION
See all commits as some clean up commits along the way.