### PR TITLE
Remove EventualsGrpcTest: it's unneeded after #339

### DIFF
--- a/test/grpc/accept.cc
+++ b/test/grpc/accept.cc
@@ -15,7 +15,7 @@ using eventuals::Head;
 using eventuals::grpc::ServerBuilder;
 using eventuals::grpc::Stream;
 
-TEST_F(EventualsGrpcTest, ServeValidate) {
+TEST(AcceptTest, ServeValidate) {
   ServerBuilder builder;
 
   builder.AddListeningPort("0.0.0.0:0", grpc::InsecureServerCredentials());

--- a/test/grpc/build-and-start.cc
+++ b/test/grpc/build-and-start.cc
@@ -4,7 +4,7 @@
 
 using eventuals::grpc::ServerBuilder;
 
-TEST_F(EventualsGrpcTest, BuildAndStart) {
+TEST(BuildAndStartTest, Success) {
   ServerBuilder builder;
 
   builder.AddListeningPort("0.0.0.0:0", grpc::InsecureServerCredentials());

--- a/test/grpc/cancelled-by-client.cc
+++ b/test/grpc/cancelled-by-client.cc
@@ -23,7 +23,7 @@ using eventuals::grpc::CompletionPool;
 using eventuals::grpc::Server;
 using eventuals::grpc::ServerBuilder;
 
-TEST_F(EventualsGrpcTest, CancelledByClient) {
+TEST(CancelledByClientTest, Cancelled) {
   ServerBuilder builder;
 
   int port = 0;

--- a/test/grpc/cancelled-by-server.cc
+++ b/test/grpc/cancelled-by-server.cc
@@ -23,7 +23,7 @@ using eventuals::grpc::CompletionPool;
 using eventuals::grpc::Server;
 using eventuals::grpc::ServerBuilder;
 
-TEST_F(EventualsGrpcTest, CancelledByServer) {
+TEST(CancelledByServerTest, Cancelled) {
   ServerBuilder builder;
 
   int port = 0;

--- a/test/grpc/client-death-test.cc
+++ b/test/grpc/client-death-test.cc
@@ -26,7 +26,7 @@ using eventuals::grpc::ServerBuilder;
 
 // Tests that servers correctly handle clients that disconnect before sending a
 // request.
-TEST_F(EventualsGrpcTest, ClientDeathTest) {
+TEST(ClientDeathTest, ServerHandlesClientDisconnect) {
   // Start a server that will handle requests.
   ServerBuilder builder;
 

--- a/test/grpc/deadline.cc
+++ b/test/grpc/deadline.cc
@@ -26,7 +26,7 @@ using eventuals::grpc::CompletionPool;
 using eventuals::grpc::Server;
 using eventuals::grpc::ServerBuilder;
 
-TEST_F(EventualsGrpcTest, Deadline) {
+TEST(DeadlineTest, DeadlineExceeded) {
   ServerBuilder builder;
 
   int port = 0;

--- a/test/grpc/greeter-server.cc
+++ b/test/grpc/greeter-server.cc
@@ -34,7 +34,7 @@ class GreeterServiceImpl final : public Greeter::Service<GreeterServiceImpl> {
   }
 };
 
-TEST_F(EventualsGrpcTest, Greeter) {
+TEST(GreeterServerTest, SayHello) {
   std::string server_address("0.0.0.0:50051");
   GreeterServiceImpl service;
 

--- a/test/grpc/main.cc
+++ b/test/grpc/main.cc
@@ -1,3 +1,4 @@
+#include "glog/logging.h"
 #include "gtest/gtest.h"
 #include "test/grpc/test.h"
 #include "tools/cpp/runfiles/runfiles.h"

--- a/test/grpc/multiple-hosts.cc
+++ b/test/grpc/multiple-hosts.cc
@@ -24,7 +24,7 @@ using eventuals::grpc::CompletionPool;
 using eventuals::grpc::Server;
 using eventuals::grpc::ServerBuilder;
 
-TEST_F(EventualsGrpcTest, MultipleHosts) {
+TEST(MultipleHostsTest, Success) {
   ServerBuilder builder;
 
   int port = 0;

--- a/test/grpc/server-death-test.cc
+++ b/test/grpc/server-death-test.cc
@@ -33,7 +33,7 @@ using eventuals::grpc::ServerBuilder;
 
 // Tests that the client receives a ::grpc::UNAVAILABLE status if the server
 // dies without cleanly calling call.Finish().
-TEST_F(EventualsGrpcTest, ServerDeathTest) {
+TEST(ServerDeathTest, ClientReceivesUnavailable) {
   // NOTE: need pipes to get the server's port, this also helps
   // synchronize when the server is ready to have the client connect.
   int pipefds[2]; // 'port[0]' is for reading, 'port[1]' for writing.

--- a/test/grpc/server-unavailable.cc
+++ b/test/grpc/server-unavailable.cc
@@ -18,7 +18,7 @@ using eventuals::grpc::Client;
 using eventuals::grpc::CompletionPool;
 using eventuals::grpc::Stream;
 
-TEST_F(EventualsGrpcTest, ServerUnavailable) {
+TEST(ServerUnavailableTest, NonexistantServer) {
   Borrowable<CompletionPool> pool;
 
   // NOTE: we use 'getpid()' to create a _unique_ UNIX domain socket

--- a/test/grpc/streaming.cc
+++ b/test/grpc/streaming.cc
@@ -120,7 +120,7 @@ void test_client_behavior(Handler handler) {
   EXPECT_FALSE(cancelled.get());
 }
 
-TEST_F(EventualsGrpcTest, Streaming_WriteLast_AfterReply_TwoRequests) {
+TEST(StreamingTest, WriteLast_AfterReply_TwoRequests) {
   test_client_behavior(
       Then(Let([](auto& call) {
         keyvaluestore::Request request;
@@ -158,7 +158,7 @@ TEST_F(EventualsGrpcTest, Streaming_WriteLast_AfterReply_TwoRequests) {
       })));
 }
 
-TEST_F(EventualsGrpcTest, Streaming_WriteLast_BeforeReply_OneRequest) {
+TEST(StreamingTest, WriteLast_BeforeReply_OneRequest) {
   test_client_behavior(
       Then(Let([](auto& call) {
         keyvaluestore::Request request;
@@ -188,7 +188,7 @@ TEST_F(EventualsGrpcTest, Streaming_WriteLast_BeforeReply_OneRequest) {
       })));
 }
 
-TEST_F(EventualsGrpcTest, Streaming_WriteLast_BeforeReply_TwoRequests) {
+TEST(StreamingTest, WriteLast_BeforeReply_TwoRequests) {
   test_client_behavior(
       Then(Let([](auto& call) {
         keyvaluestore::Request request1;
@@ -228,7 +228,7 @@ TEST_F(EventualsGrpcTest, Streaming_WriteLast_BeforeReply_TwoRequests) {
       })));
 }
 
-TEST_F(EventualsGrpcTest, Streaming_WritesDone_AfterReply_OneRequest) {
+TEST(StreamingTest, WritesDone_AfterReply_OneRequest) {
   test_client_behavior(
       Then(Let([](auto& call) {
         keyvaluestore::Request request;
@@ -259,7 +259,7 @@ TEST_F(EventualsGrpcTest, Streaming_WritesDone_AfterReply_OneRequest) {
       })));
 }
 
-TEST_F(EventualsGrpcTest, Streaming_WritesDone_AfterReply_TwoRequests) {
+TEST(StreamingTest, WritesDone_AfterReply_TwoRequests) {
   test_client_behavior(
       Then(Let([](auto& call) {
         keyvaluestore::Request request;
@@ -298,7 +298,7 @@ TEST_F(EventualsGrpcTest, Streaming_WritesDone_AfterReply_TwoRequests) {
       })));
 }
 
-TEST_F(EventualsGrpcTest, Streaming_WritesDone_BeforeReply_OneRequest) {
+TEST(StreamingTest, WritesDone_BeforeReply_OneRequest) {
   test_client_behavior(
       Then(Let([](auto& call) {
         keyvaluestore::Request request1;
@@ -329,7 +329,7 @@ TEST_F(EventualsGrpcTest, Streaming_WritesDone_BeforeReply_OneRequest) {
       })));
 }
 
-TEST_F(EventualsGrpcTest, Streaming_WritesDone_BeforeReply_TwoRequests) {
+TEST(StreamingTest, WritesDone_BeforeReply_TwoRequests) {
   test_client_behavior(
       Then(Let([](auto& call) {
         keyvaluestore::Request request1;

--- a/test/grpc/test.h
+++ b/test/grpc/test.h
@@ -2,36 +2,8 @@
 
 #include <filesystem>
 
-#include "eventuals/grpc/server.h"
-#include "gtest/gtest.h"
-
-////////////////////////////////////////////////////////////////////////
-
-class EventualsGrpcTest : public ::testing::Test {
- protected:
-  void SetUp() override {
-    ASSERT_EQ(1, GetThreadCount());
-  }
-
-  void TearDown() override {
-    // NOTE: need to wait until all internal threads created by the
-    // grpc library have completed because some of our tests are death
-    // tests which fork.
-    while (GetThreadCount() != 1) {}
-  }
-
-  size_t GetThreadCount() {
-    // TODO(benh): Don't rely on the internal 'GetThreadCount()'.
-    return testing::internal::GetThreadCount();
-  }
-};
-
-////////////////////////////////////////////////////////////////////////
-
 // Helper which returns a path for the specified runfile. This is a
 // wrapper around 'bazel::tools::cpp::runfiles::Runfiles' which
 // amongst other things uses 'std::filesystem::path' instead of just
 // 'std::string'.
 std::filesystem::path GetRunfilePathFor(const std::filesystem::path& runfile);
-
-////////////////////////////////////////////////////////////////////////

--- a/test/grpc/unary.cc
+++ b/test/grpc/unary.cc
@@ -28,7 +28,7 @@ using eventuals::grpc::Server;
 using eventuals::grpc::ServerBuilder;
 using eventuals::grpc::ServerCall;
 
-TEST_F(EventualsGrpcTest, Unary) {
+TEST(UnaryTest, Success) {
   ServerBuilder builder;
 
   int port = 0;

--- a/test/grpc/unimplemented.cc
+++ b/test/grpc/unimplemented.cc
@@ -17,7 +17,7 @@ using eventuals::grpc::Client;
 using eventuals::grpc::CompletionPool;
 using eventuals::grpc::ServerBuilder;
 
-TEST_F(EventualsGrpcTest, Unimplemented) {
+TEST(UnimplementedTest, ClientCallsUnimplementedServerMethod) {
   ServerBuilder builder;
 
   int port = 0;


### PR DESCRIPTION
https://github.com/3rdparty/eventuals/pull/339 removed all uses of
`ASSERT_DEATH`. Tests no longer create detached threads (tests which
create threads now explicitly `join` those threads) so we no longer need
a test fixture to handle thread joining.
