### PR TITLE
Move tests into named namespaces

### DIFF
--- a/test/callback.cc
+++ b/test/callback.cc
@@ -3,7 +3,8 @@
 #include "gtest/gtest.h"
 #include "stout/borrowed_ptr.h"
 
-using eventuals::Callback;
+namespace eventuals::test {
+namespace {
 
 TEST(Callback, Destructor) {
   struct Foo {
@@ -64,3 +65,6 @@ TEST(Callback, BorrowedCallable) {
 
   EXPECT_EQ(foo.borrows(), 0);
 }
+
+} // namespace
+} // namespace eventuals::test

--- a/test/catch.cc
+++ b/test/catch.cc
@@ -14,16 +14,9 @@
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
-using eventuals::Catch;
-using eventuals::Conditional;
-using eventuals::Eventual;
-using eventuals::Expected;
-using eventuals::Interrupt;
-using eventuals::Just;
-using eventuals::Raise;
-using eventuals::Terminate;
-using eventuals::Then;
-using eventuals::Unexpected;
+namespace eventuals::test {
+namespace {
+
 using testing::MockFunction;
 
 TEST(CatchTest, RaisedRuntimeError) {
@@ -308,3 +301,6 @@ TEST(CatchTest, Interrupt) {
 
   EXPECT_EQ(future.get(), "100");
 }
+
+} // namespace
+} // namespace eventuals::test

--- a/test/closure.cc
+++ b/test/closure.cc
@@ -16,20 +16,11 @@
 #include "gtest/gtest.h"
 #include "test/expect-throw-what.h"
 
+namespace eventuals::test {
+namespace {
+
 using std::deque;
 using std::string;
-
-using eventuals::Closure;
-using eventuals::Eventual;
-using eventuals::Interrupt;
-using eventuals::Just;
-using eventuals::Map;
-using eventuals::Raise;
-using eventuals::Reduce;
-using eventuals::Repeat;
-using eventuals::Terminate;
-using eventuals::Then;
-using eventuals::Until;
 
 using testing::ElementsAre;
 using testing::MockFunction;
@@ -162,3 +153,6 @@ TEST(ClosureTest, Interrupt) {
 
   EXPECT_THROW(future.get(), eventuals::StoppedException);
 }
+
+} // namespace
+} // namespace eventuals::test

--- a/test/collect.cc
+++ b/test/collect.cc
@@ -7,8 +7,8 @@
 #include "eventuals/terminal.h"
 #include "gtest/gtest.h"
 
-using eventuals::Collect;
-using eventuals::Iterate;
+namespace eventuals::test {
+namespace {
 
 TEST(Collect, CommonVectorPass) {
   std::vector<int> v = {5, 12};
@@ -39,3 +39,6 @@ TEST(Collect, CommonSetPass) {
   EXPECT_EQ(5, *result.begin());
   EXPECT_EQ(12, *++result.begin());
 }
+
+} // namespace
+} // namespace eventuals::test

--- a/test/concurrent/concurrent-downstream-done-both-eventuals-success.cc
+++ b/test/concurrent/concurrent-downstream-done-both-eventuals-success.cc
@@ -12,14 +12,8 @@
 #include "eventuals/then.h"
 #include "test/concurrent/concurrent.h"
 
-using eventuals::Callback;
-using eventuals::Eventual;
-using eventuals::Iterate;
-using eventuals::Let;
-using eventuals::Map;
-using eventuals::Reduce;
-using eventuals::Terminate;
-using eventuals::Then;
+namespace eventuals::test {
+namespace {
 
 // Tests what happens when downstream is done before 'Concurrent()' is
 // done and each eventual succeeds.
@@ -81,3 +75,6 @@ TYPED_TEST(ConcurrentTypedTest, DownstreamDoneBothEventualsSuccess) {
     EXPECT_EQ(values[0], future.get());
   }
 }
+
+} // namespace
+} // namespace eventuals::test

--- a/test/concurrent/concurrent-downstream-done-one-eventual-fail.cc
+++ b/test/concurrent/concurrent-downstream-done-one-eventual-fail.cc
@@ -12,15 +12,8 @@
 #include "eventuals/then.h"
 #include "test/concurrent/concurrent.h"
 
-using eventuals::Callback;
-using eventuals::Eventual;
-using eventuals::Interrupt;
-using eventuals::Iterate;
-using eventuals::Let;
-using eventuals::Map;
-using eventuals::Reduce;
-using eventuals::Terminate;
-using eventuals::Then;
+namespace eventuals::test {
+namespace {
 
 // Tests what happens when downstream is done before 'Concurrent()' is
 // done and one eventual fails.
@@ -79,3 +72,6 @@ TYPED_TEST(ConcurrentTypedTest, DownstreamDoneOneEventualFail) {
 
   EXPECT_EQ("1", future.get());
 }
+
+} // namespace
+} // namespace eventuals::test

--- a/test/concurrent/concurrent-downstream-done-one-eventual-stop.cc
+++ b/test/concurrent/concurrent-downstream-done-one-eventual-stop.cc
@@ -12,15 +12,8 @@
 #include "eventuals/then.h"
 #include "test/concurrent/concurrent.h"
 
-using eventuals::Callback;
-using eventuals::Eventual;
-using eventuals::Interrupt;
-using eventuals::Iterate;
-using eventuals::Let;
-using eventuals::Map;
-using eventuals::Reduce;
-using eventuals::Terminate;
-using eventuals::Then;
+namespace eventuals::test {
+namespace {
 
 // Tests what happens when downstream is done before 'Concurrent()' is
 // done and one eventual stops.
@@ -78,3 +71,6 @@ TYPED_TEST(ConcurrentTypedTest, DownstreamDoneOneEventualStop) {
 
   EXPECT_EQ("1", future.get());
 }
+
+} // namespace
+} // namespace eventuals::test

--- a/test/concurrent/concurrent-emit-fail-interrupt.cc
+++ b/test/concurrent/concurrent-emit-fail-interrupt.cc
@@ -11,13 +11,8 @@
 #include "test/concurrent/concurrent.h"
 #include "test/expect-throw-what.h"
 
-using eventuals::Collect;
-using eventuals::Eventual;
-using eventuals::Interrupt;
-using eventuals::Let;
-using eventuals::Map;
-using eventuals::Stream;
-using eventuals::Terminate;
+namespace eventuals::test {
+namespace {
 
 // Tests that when one of the 'Concurrent()' eventuals fails it can
 // ensure that everything correctly fails by "interrupting"
@@ -71,3 +66,6 @@ TYPED_TEST(ConcurrentTypedTest, EmitFailInterrupt) {
 
   EXPECT_THROW_WHAT(future.get(), "error");
 }
+
+} // namespace
+} // namespace eventuals::test

--- a/test/concurrent/concurrent-emit-interrupt-fail.cc
+++ b/test/concurrent/concurrent-emit-interrupt-fail.cc
@@ -9,11 +9,8 @@
 #include "test/concurrent/concurrent.h"
 #include "test/expect-throw-what.h"
 
-using eventuals::Collect;
-using eventuals::Interrupt;
-using eventuals::Map;
-using eventuals::Stream;
-using eventuals::Terminate;
+namespace eventuals::test {
+namespace {
 
 // Tests when when upstream fails after an interrupt the result will
 // be fail.
@@ -63,3 +60,6 @@ TYPED_TEST(ConcurrentTypedTest, EmitInterruptFail) {
 
   EXPECT_THROW_WHAT(future.get(), "error");
 }
+
+} // namespace
+} // namespace eventuals::test

--- a/test/concurrent/concurrent-emit-interrupt-stop.cc
+++ b/test/concurrent/concurrent-emit-interrupt-stop.cc
@@ -8,11 +8,8 @@
 #include "eventuals/terminal.h"
 #include "test/concurrent/concurrent.h"
 
-using eventuals::Collect;
-using eventuals::Interrupt;
-using eventuals::Map;
-using eventuals::Stream;
-using eventuals::Terminate;
+namespace eventuals::test {
+namespace {
 
 // Tests when when upstream stops after an interrupt the result will
 // be stop.
@@ -61,3 +58,6 @@ TYPED_TEST(ConcurrentTypedTest, EmitInterruptStop) {
 
   EXPECT_THROW(future.get(), eventuals::StoppedException);
 }
+
+} // namespace
+} // namespace eventuals::test

--- a/test/concurrent/concurrent-emit-stop-interrupt.cc
+++ b/test/concurrent/concurrent-emit-stop-interrupt.cc
@@ -10,13 +10,8 @@
 #include "eventuals/terminal.h"
 #include "test/concurrent/concurrent.h"
 
-using eventuals::Collect;
-using eventuals::Eventual;
-using eventuals::Interrupt;
-using eventuals::Let;
-using eventuals::Map;
-using eventuals::Stream;
-using eventuals::Terminate;
+namespace eventuals::test {
+namespace {
 
 // Same as 'EmitFailInterrupt' except each eventual stops not fails.
 TYPED_TEST(ConcurrentTypedTest, EmitStopInterrupt) {
@@ -61,3 +56,6 @@ TYPED_TEST(ConcurrentTypedTest, EmitStopInterrupt) {
 
   EXPECT_THROW(future.get(), eventuals::StoppedException);
 }
+
+} // namespace
+} // namespace eventuals::test

--- a/test/concurrent/concurrent-fail-before-start.cc
+++ b/test/concurrent/concurrent-fail-before-start.cc
@@ -11,13 +11,8 @@
 #include "test/concurrent/concurrent.h"
 #include "test/expect-throw-what.h"
 
-using eventuals::Callback;
-using eventuals::Collect;
-using eventuals::Eventual;
-using eventuals::Iterate;
-using eventuals::Let;
-using eventuals::Map;
-using eventuals::Terminate;
+namespace eventuals::test {
+namespace {
 
 // Tests when an eventuals fails before an eventual succeeds.
 TYPED_TEST(ConcurrentTypedTest, FailBeforeStart) {
@@ -77,3 +72,6 @@ TYPED_TEST(ConcurrentTypedTest, FailBeforeStart) {
 
   EXPECT_THROW_WHAT(future.get(), "error");
 }
+
+} // namespace
+} // namespace eventuals::test

--- a/test/concurrent/concurrent-fail-or-stop.cc
+++ b/test/concurrent/concurrent-fail-or-stop.cc
@@ -11,13 +11,8 @@
 #include "eventuals/terminal.h"
 #include "test/concurrent/concurrent.h"
 
-using eventuals::Callback;
-using eventuals::Collect;
-using eventuals::Eventual;
-using eventuals::Iterate;
-using eventuals::Let;
-using eventuals::Map;
-using eventuals::Terminate;
+namespace eventuals::test {
+namespace {
 
 // Tests when every eventual either stops or fails.
 TYPED_TEST(ConcurrentTypedTest, FailOrStop) {
@@ -80,3 +75,6 @@ TYPED_TEST(ConcurrentTypedTest, FailOrStop) {
     EXPECT_THROW(future.get(), eventuals::StoppedException);
   }
 }
+
+} // namespace
+} // namespace eventuals::test

--- a/test/concurrent/concurrent-fail.cc
+++ b/test/concurrent/concurrent-fail.cc
@@ -12,13 +12,8 @@
 #include "test/concurrent/concurrent.h"
 #include "test/expect-throw-what.h"
 
-using eventuals::Callback;
-using eventuals::Collect;
-using eventuals::Eventual;
-using eventuals::Iterate;
-using eventuals::Let;
-using eventuals::Map;
-using eventuals::Terminate;
+namespace eventuals::test {
+namespace {
 
 // Tests when at least one of the eventuals fails.
 TYPED_TEST(ConcurrentTypedTest, Fail) {
@@ -73,3 +68,6 @@ TYPED_TEST(ConcurrentTypedTest, Fail) {
 
   EXPECT_THROW_WHAT(future.get(), "error");
 }
+
+} // namespace
+} // namespace eventuals::test

--- a/test/concurrent/concurrent-flat-map.cc
+++ b/test/concurrent/concurrent-flat-map.cc
@@ -8,11 +8,8 @@
 #include "eventuals/terminal.h"
 #include "test/concurrent/concurrent.h"
 
-using eventuals::Collect;
-using eventuals::FlatMap;
-using eventuals::Iterate;
-using eventuals::Range;
-using eventuals::Terminate;
+namespace eventuals::test {
+namespace {
 
 // Tests that one can nest 'FlatMap()' within a
 // 'Concurrent()' or 'ConcurrentOrdered()'.
@@ -38,3 +35,6 @@ TYPED_TEST(ConcurrentTypedTest, FlatMap) {
 
   EXPECT_THAT(future.get(), this->OrderedOrUnorderedElementsAre(0, 0, 1));
 }
+
+} // namespace
+} // namespace eventuals::test

--- a/test/concurrent/concurrent-interrupt-fail-or-stop.cc
+++ b/test/concurrent/concurrent-interrupt-fail-or-stop.cc
@@ -13,14 +13,8 @@
 #include "test/concurrent/concurrent.h"
 #include "test/expect-throw-what.h"
 
-using eventuals::Callback;
-using eventuals::Collect;
-using eventuals::Eventual;
-using eventuals::Interrupt;
-using eventuals::Iterate;
-using eventuals::Let;
-using eventuals::Map;
-using eventuals::Terminate;
+namespace eventuals::test {
+namespace {
 
 // Tests that 'Concurrent()' and 'ConcurrentOrdered()' defers to the
 // eventuals on how to handle interrupts and in this case one of the
@@ -83,3 +77,6 @@ TYPED_TEST(ConcurrentTypedTest, InterruptFailOrStop) {
     EXPECT_THROW_WHAT(future.get(), "error");
   }
 }
+
+} // namespace
+} // namespace eventuals::test

--- a/test/concurrent/concurrent-interrupt-fail.cc
+++ b/test/concurrent/concurrent-interrupt-fail.cc
@@ -13,14 +13,8 @@
 #include "test/concurrent/concurrent.h"
 #include "test/expect-throw-what.h"
 
-using eventuals::Callback;
-using eventuals::Collect;
-using eventuals::Eventual;
-using eventuals::Interrupt;
-using eventuals::Iterate;
-using eventuals::Let;
-using eventuals::Map;
-using eventuals::Terminate;
+namespace eventuals::test {
+namespace {
 
 // Tests that 'Concurrent()' and 'ConcurrentOrdered()' defers to the
 // eventuals on how to handle interrupts and in this case both of the
@@ -70,3 +64,6 @@ TYPED_TEST(ConcurrentTypedTest, InterruptFail) {
 
   EXPECT_THROW_WHAT(future.get(), "error");
 }
+
+} // namespace
+} // namespace eventuals::test

--- a/test/concurrent/concurrent-interrupt-stop.cc
+++ b/test/concurrent/concurrent-interrupt-stop.cc
@@ -12,14 +12,8 @@
 #include "eventuals/terminal.h"
 #include "test/concurrent/concurrent.h"
 
-using eventuals::Callback;
-using eventuals::Collect;
-using eventuals::Eventual;
-using eventuals::Interrupt;
-using eventuals::Iterate;
-using eventuals::Let;
-using eventuals::Map;
-using eventuals::Terminate;
+namespace eventuals::test {
+namespace {
 
 // Tests that 'Concurrent()' and 'ConcurrentOrdered()' defers to the
 // eventuals on how to handle interrupts and in this case one all of
@@ -67,3 +61,6 @@ TYPED_TEST(ConcurrentTypedTest, InterruptStop) {
 
   EXPECT_THROW(future.get(), eventuals::StoppedException);
 }
+
+} // namespace
+} // namespace eventuals::test

--- a/test/concurrent/concurrent-interrupt-success.cc
+++ b/test/concurrent/concurrent-interrupt-success.cc
@@ -12,14 +12,8 @@
 #include "eventuals/terminal.h"
 #include "test/concurrent/concurrent.h"
 
-using eventuals::Callback;
-using eventuals::Collect;
-using eventuals::Eventual;
-using eventuals::Interrupt;
-using eventuals::Iterate;
-using eventuals::Let;
-using eventuals::Map;
-using eventuals::Terminate;
+namespace eventuals::test {
+namespace {
 
 // Tests that 'Concurrent()' and 'ConcurrentOrdered()' defers to the
 // eventuals on how to handle interrupts and in this case each eventual
@@ -80,3 +74,6 @@ TYPED_TEST(ConcurrentTypedTest, InterruptSuccess) {
 
   EXPECT_THAT(future.get(), this->OrderedOrUnorderedElementsAre("1", "2"));
 }
+
+} // namespace
+} // namespace eventuals::test

--- a/test/concurrent/concurrent-moveable.cc
+++ b/test/concurrent/concurrent-moveable.cc
@@ -8,12 +8,8 @@
 #include "eventuals/terminal.h"
 #include "test/concurrent/concurrent.h"
 
-using eventuals::Collect;
-using eventuals::Interrupt;
-using eventuals::Iterate;
-using eventuals::Let;
-using eventuals::Map;
-using eventuals::Terminate;
+namespace eventuals::test {
+namespace {
 
 // Tests that only moveable values will be moved into
 // 'Concurrent()' and 'ConcurrentOrdered()'.
@@ -44,3 +40,6 @@ TYPED_TEST(ConcurrentTypedTest, Moveable) {
 
   EXPECT_THAT(future.get(), this->OrderedOrUnorderedElementsAre(42));
 }
+
+} // namespace
+} // namespace eventuals::test

--- a/test/concurrent/concurrent-stop-before-start.cc
+++ b/test/concurrent/concurrent-stop-before-start.cc
@@ -10,13 +10,8 @@
 #include "eventuals/terminal.h"
 #include "test/concurrent/concurrent.h"
 
-using eventuals::Callback;
-using eventuals::Collect;
-using eventuals::Eventual;
-using eventuals::Iterate;
-using eventuals::Let;
-using eventuals::Map;
-using eventuals::Terminate;
+namespace eventuals::test {
+namespace {
 
 // Tests when an eventuals stops before an eventual succeeds.
 TYPED_TEST(ConcurrentTypedTest, StopBeforeStart) {
@@ -73,3 +68,6 @@ TYPED_TEST(ConcurrentTypedTest, StopBeforeStart) {
 
   EXPECT_THROW(future.get(), eventuals::StoppedException);
 }
+
+} // namespace
+} // namespace eventuals::test

--- a/test/concurrent/concurrent-stop.cc
+++ b/test/concurrent/concurrent-stop.cc
@@ -11,14 +11,8 @@
 #include "eventuals/terminal.h"
 #include "test/concurrent/concurrent.h"
 
-using eventuals::Callback;
-using eventuals::Collect;
-using eventuals::Eventual;
-using eventuals::Interrupt;
-using eventuals::Iterate;
-using eventuals::Let;
-using eventuals::Map;
-using eventuals::Terminate;
+namespace eventuals::test {
+namespace {
 
 // Tests when at least one of the eventuals stops.
 TYPED_TEST(ConcurrentTypedTest, Stop) {
@@ -71,3 +65,6 @@ TYPED_TEST(ConcurrentTypedTest, Stop) {
 
   EXPECT_THROW(future.get(), eventuals::StoppedException);
 }
+
+} // namespace
+} // namespace eventuals::test

--- a/test/concurrent/concurrent-stream-fail.cc
+++ b/test/concurrent/concurrent-stream-fail.cc
@@ -8,10 +8,8 @@
 #include "test/concurrent/concurrent.h"
 #include "test/expect-throw-what.h"
 
-using eventuals::Collect;
-using eventuals::Map;
-using eventuals::Stream;
-using eventuals::Terminate;
+namespace eventuals::test {
+namespace {
 
 // Tests when when upstream fails the result will be fail.
 TYPED_TEST(ConcurrentTypedTest, StreamFail) {
@@ -41,3 +39,6 @@ TYPED_TEST(ConcurrentTypedTest, StreamFail) {
 
   EXPECT_THROW_WHAT(future.get(), "error");
 }
+
+} // namespace
+} // namespace eventuals::test

--- a/test/concurrent/concurrent-stream-stop.cc
+++ b/test/concurrent/concurrent-stream-stop.cc
@@ -7,10 +7,8 @@
 #include "eventuals/terminal.h"
 #include "test/concurrent/concurrent.h"
 
-using eventuals::Collect;
-using eventuals::Map;
-using eventuals::Stream;
-using eventuals::Terminate;
+namespace eventuals::test {
+namespace {
 
 // Tests when when upstream stops the result will be stop.
 TYPED_TEST(ConcurrentTypedTest, StreamStop) {
@@ -38,3 +36,6 @@ TYPED_TEST(ConcurrentTypedTest, StreamStop) {
 
   EXPECT_THROW(future.get(), eventuals::StoppedException);
 }
+
+} // namespace
+} // namespace eventuals::test

--- a/test/concurrent/concurrent-success.cc
+++ b/test/concurrent/concurrent-success.cc
@@ -11,13 +11,8 @@
 #include "eventuals/terminal.h"
 #include "test/concurrent/concurrent.h"
 
-using eventuals::Callback;
-using eventuals::Collect;
-using eventuals::Eventual;
-using eventuals::Iterate;
-using eventuals::Let;
-using eventuals::Map;
-using eventuals::Terminate;
+namespace eventuals::test {
+namespace {
 
 // Tests when all eventuals are successful.
 TYPED_TEST(ConcurrentTypedTest, Success) {
@@ -66,3 +61,6 @@ TYPED_TEST(ConcurrentTypedTest, Success) {
 
   EXPECT_THAT(future.get(), this->OrderedOrUnorderedElementsAre("1", "2"));
 }
+
+} // namespace
+} // namespace eventuals::test

--- a/test/concurrent/concurrent.h
+++ b/test/concurrent/concurrent.h
@@ -5,6 +5,8 @@
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
+namespace eventuals::test {
+
 struct ConcurrentType {};
 struct ConcurrentOrderedType {};
 
@@ -33,3 +35,5 @@ class ConcurrentTypedTest : public testing::Test {
 using ConcurrentTypes = testing::Types<ConcurrentType, ConcurrentOrderedType>;
 
 TYPED_TEST_SUITE(ConcurrentTypedTest, ConcurrentTypes);
+
+} // namespace eventuals::test

--- a/test/conditional.cc
+++ b/test/conditional.cc
@@ -10,15 +10,10 @@
 #include "gtest/gtest.h"
 #include "test/expect-throw-what.h"
 
-using std::string;
+namespace eventuals::test {
+namespace {
 
-using eventuals::Conditional;
-using eventuals::Eventual;
-using eventuals::Interrupt;
-using eventuals::Just;
-using eventuals::Raise;
-using eventuals::Terminate;
-using eventuals::Then;
+using std::string;
 
 using testing::MockFunction;
 
@@ -184,3 +179,6 @@ TEST(ConditionalTest, Raise) {
 
   EXPECT_EQ(2, *c());
 }
+
+} // namespace
+} // namespace eventuals::test

--- a/test/dns-resolver.cc
+++ b/test/dns-resolver.cc
@@ -11,11 +11,8 @@
 #include "test/event-loop-test.h"
 #include "test/expect-throw-what.h"
 
-using eventuals::DomainNameResolve;
-using eventuals::EventLoop;
-using eventuals::Eventual;
-using eventuals::Terminate;
-using eventuals::Then;
+namespace eventuals::test {
+namespace {
 
 using testing::MockFunction;
 
@@ -123,3 +120,6 @@ TEST_F(DomainNameResolveTest, Raises) {
 
   EXPECT_THROW_WHAT(future.get(), "error");
 }
+
+} // namespace
+} // namespace eventuals::test

--- a/test/do-all.cc
+++ b/test/do-all.cc
@@ -7,13 +7,8 @@
 #include "gtest/gtest.h"
 #include "test/expect-throw-what.h"
 
-using eventuals::Build;
-using eventuals::DoAll;
-using eventuals::Eventual;
-using eventuals::Interrupt;
-using eventuals::Terminal;
-using eventuals::Terminate;
-using eventuals::Then;
+namespace eventuals::test {
+namespace {
 
 using testing::MockFunction;
 
@@ -96,3 +91,6 @@ TEST(DoAllTest, Interrupt) {
 
   EXPECT_THROW(future.get(), eventuals::StoppedException);
 }
+
+} // namespace
+} // namespace eventuals::test

--- a/test/event-loop-test.h
+++ b/test/event-loop-test.h
@@ -3,6 +3,8 @@
 #include "eventuals/event-loop.h"
 #include "gtest/gtest.h"
 
+namespace eventuals::test {
+
 class EventLoopTest : public ::testing::Test {
  protected:
   void SetUp() override {
@@ -13,3 +15,5 @@ class EventLoopTest : public ::testing::Test {
     eventuals::EventLoop::DestructDefault();
   }
 };
+
+} // namespace eventuals::test

--- a/test/eventual.cc
+++ b/test/eventual.cc
@@ -14,16 +14,8 @@
 #include "gtest/gtest.h"
 #include "test/expect-throw-what.h"
 
-using eventuals::Build;
-using eventuals::Catch;
-using eventuals::Eventual;
-using eventuals::Interrupt;
-using eventuals::Just;
-using eventuals::Let;
-using eventuals::Raise;
-using eventuals::Terminal;
-using eventuals::Terminate;
-using eventuals::Then;
+namespace eventuals::test {
+namespace {
 
 using testing::MockFunction;
 
@@ -328,3 +320,6 @@ TEST(EventualTest, Ref) {
 
   EXPECT_EQ(110, x);
 }
+
+} // namespace
+} // namespace eventuals::test

--- a/test/executor.cc
+++ b/test/executor.cc
@@ -8,12 +8,8 @@
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
-using eventuals::Eventual;
-using eventuals::Executor;
-using eventuals::Interrupt;
-using eventuals::Just;
-using eventuals::Task;
-using eventuals::Then;
+namespace eventuals::test {
+namespace {
 
 TEST(ExecutorTest, Succeed) {
   bool executed = false;
@@ -71,3 +67,6 @@ TEST(ExecutorTest, Interrupt) {
 
   EXPECT_TRUE(interrupted);
 }
+
+} // namespace
+} // namespace eventuals::test

--- a/test/expected.cc
+++ b/test/expected.cc
@@ -7,9 +7,8 @@
 #include "gtest/gtest.h"
 #include "test/expect-throw-what.h"
 
-using eventuals::Expected;
-using eventuals::Then;
-using eventuals::Unexpected;
+namespace eventuals::test {
+namespace {
 
 TEST(Expected, Construct) {
   Expected::Of<std::string> s = "hello world";
@@ -172,3 +171,6 @@ TEST(Expected, ExpectedNoErrors) {
 
   EXPECT_EQ(42, *e());
 }
+
+} // namespace
+} // namespace eventuals::test

--- a/test/filesystem.cc
+++ b/test/filesystem.cc
@@ -11,23 +11,10 @@
 #include "gtest/gtest.h"
 #include "test/expect-throw-what.h"
 
-using eventuals::Closure;
-using eventuals::EventLoop;
-using eventuals::Terminate;
-using eventuals::Then;
+namespace eventuals::filesystem::test {
+namespace {
 
-using eventuals::filesystem::CloseFile;
-using eventuals::filesystem::CopyFile;
-using eventuals::filesystem::File;
-using eventuals::filesystem::MakeDirectory;
-using eventuals::filesystem::OpenFile;
-using eventuals::filesystem::ReadFile;
-using eventuals::filesystem::RemoveDirectory;
-using eventuals::filesystem::RenameFile;
-using eventuals::filesystem::UnlinkFile;
-using eventuals::filesystem::WriteFile;
-
-class FilesystemTest : public EventLoopTest {};
+class FilesystemTest : public ::eventuals::test::EventLoopTest {};
 
 
 TEST_F(FilesystemTest, OpenAndCloseFileSucceed) {
@@ -428,3 +415,6 @@ TEST_F(FilesystemTest, RenameFileFail) {
 
   EXPECT_THROW_WHAT(future.get(), "no such file or directory");
 }
+
+} // namespace
+} // namespace eventuals::filesystem::test

--- a/test/filter.cc
+++ b/test/filter.cc
@@ -12,11 +12,8 @@
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
-using eventuals::Collect;
-using eventuals::Filter;
-using eventuals::Iterate;
-using eventuals::Loop;
-using eventuals::Map;
+namespace eventuals::test {
+namespace {
 
 using testing::ElementsAre;
 using testing::UnorderedElementsAre;
@@ -92,3 +89,6 @@ TEST(Filter, OddMapCollectFlow) {
 
   EXPECT_THAT(*s(), UnorderedElementsAre(6, 18));
 }
+
+} // namespace
+} // namespace eventuals::test

--- a/test/finally.cc
+++ b/test/finally.cc
@@ -11,14 +11,8 @@
 #include "gtest/gtest.h"
 #include "test/expect-throw-what.h"
 
-using eventuals::Catch;
-using eventuals::Eventual;
-using eventuals::Expected;
-using eventuals::Finally;
-using eventuals::If;
-using eventuals::Just;
-using eventuals::Raise;
-using eventuals::Then;
+namespace eventuals::test {
+namespace {
 
 TEST(Finally, Succeed) {
   auto e = []() {
@@ -165,3 +159,6 @@ TEST(Finally, FinallyInsideThen) {
 
   EXPECT_NO_THROW(*e());
 }
+
+} // namespace
+} // namespace eventuals::test

--- a/test/flat-map.cc
+++ b/test/flat-map.cc
@@ -21,17 +21,8 @@
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
-using eventuals::Collect;
-using eventuals::EventLoop;
-using eventuals::FlatMap;
-using eventuals::Interrupt;
-using eventuals::Iterate;
-using eventuals::Just;
-using eventuals::Let;
-using eventuals::Map;
-using eventuals::Range;
-using eventuals::Stream;
-using eventuals::Timer;
+namespace eventuals::test {
+namespace {
 
 using testing::ElementsAre;
 
@@ -274,3 +265,6 @@ TEST(FlatMap, InterruptReturn) {
 
   EXPECT_THROW(future.get(), eventuals::StoppedException);
 }
+
+} // namespace
+} // namespace eventuals::test

--- a/test/foreach.cc
+++ b/test/foreach.cc
@@ -7,10 +7,8 @@
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
-using eventuals::Closure;
-using eventuals::Foreach;
-using eventuals::Range;
-using eventuals::Then;
+namespace eventuals::test {
+namespace {
 
 using testing::ElementsAre;
 
@@ -30,3 +28,6 @@ TEST(Foreach, Test) {
 
   EXPECT_THAT(*e(), ElementsAre(0, 1, 2, 3, 4));
 }
+
+} // namespace
+} // namespace eventuals::test

--- a/test/generator.cc
+++ b/test/generator.cc
@@ -23,22 +23,8 @@
 #include "gtest/gtest.h"
 #include "test/expect-throw-what.h"
 
-using eventuals::Closure;
-using eventuals::Collect;
-using eventuals::Eventual;
-using eventuals::FlatMap;
-using eventuals::Generator;
-using eventuals::Interrupt;
-using eventuals::Iterate;
-using eventuals::Just;
-using eventuals::Lazy;
-using eventuals::Loop;
-using eventuals::Map;
-using eventuals::Range;
-using eventuals::Stream;
-using eventuals::Task;
-using eventuals::Terminate;
-using eventuals::Then;
+namespace eventuals::test {
+namespace {
 
 using testing::ElementsAre;
 using testing::MockFunction;
@@ -565,3 +551,6 @@ TEST(Generator, Raises) {
 
   EXPECT_THROW(*e(), std::runtime_error);
 }
+
+} // namespace
+} // namespace eventuals::test

--- a/test/grpc/accept.cc
+++ b/test/grpc/accept.cc
@@ -10,15 +10,13 @@ using helloworld::Greeter;
 using helloworld::HelloReply;
 using helloworld::HelloRequest;
 
-using eventuals::Head;
-
-using eventuals::grpc::ServerBuilder;
-using eventuals::grpc::Stream;
+namespace eventuals::grpc::test {
+namespace {
 
 TEST(AcceptTest, ServeValidate) {
   ServerBuilder builder;
 
-  builder.AddListeningPort("0.0.0.0:0", grpc::InsecureServerCredentials());
+  builder.AddListeningPort("0.0.0.0:0", ::grpc::InsecureServerCredentials());
 
   auto build = builder.BuildAndStart();
 
@@ -100,3 +98,6 @@ TEST(AcceptTest, ServeValidate) {
         "Method does not have responses of type helloworld.HelloReply");
   }
 }
+
+} // namespace
+} // namespace eventuals::grpc::test

--- a/test/grpc/build-and-start.cc
+++ b/test/grpc/build-and-start.cc
@@ -2,15 +2,19 @@
 #include "gtest/gtest.h"
 #include "test/grpc/test.h"
 
-using eventuals::grpc::ServerBuilder;
+namespace eventuals::grpc::test {
+namespace {
 
 TEST(BuildAndStartTest, Success) {
   ServerBuilder builder;
 
-  builder.AddListeningPort("0.0.0.0:0", grpc::InsecureServerCredentials());
+  builder.AddListeningPort("0.0.0.0:0", ::grpc::InsecureServerCredentials());
 
   auto build = builder.BuildAndStart();
 
   ASSERT_TRUE(build.status.ok());
   ASSERT_TRUE(build.server);
 }
+
+} // namespace
+} // namespace eventuals::grpc::test

--- a/test/grpc/cancelled-by-client.cc
+++ b/test/grpc/cancelled-by-client.cc
@@ -7,21 +7,14 @@
 #include "gtest/gtest.h"
 #include "test/grpc/test.h"
 
+namespace eventuals::grpc::test {
+namespace {
+
 using helloworld::Greeter;
 using helloworld::HelloReply;
 using helloworld::HelloRequest;
 
 using stout::Borrowable;
-
-using eventuals::Head;
-using eventuals::Let;
-using eventuals::Terminate;
-using eventuals::Then;
-
-using eventuals::grpc::Client;
-using eventuals::grpc::CompletionPool;
-using eventuals::grpc::Server;
-using eventuals::grpc::ServerBuilder;
 
 TEST(CancelledByClientTest, Cancelled) {
   ServerBuilder builder;
@@ -30,7 +23,7 @@ TEST(CancelledByClientTest, Cancelled) {
 
   builder.AddListeningPort(
       "0.0.0.0:0",
-      grpc::InsecureServerCredentials(),
+      ::grpc::InsecureServerCredentials(),
       &port);
 
   auto build = builder.BuildAndStart();
@@ -57,7 +50,7 @@ TEST(CancelledByClientTest, Cancelled) {
 
   Client client(
       "0.0.0.0:" + std::to_string(port),
-      grpc::InsecureChannelCredentials(),
+      ::grpc::InsecureChannelCredentials(),
       pool.Borrow());
 
   auto call = [&]() {
@@ -70,7 +63,10 @@ TEST(CancelledByClientTest, Cancelled) {
 
   auto status = *call();
 
-  EXPECT_EQ(grpc::CANCELLED, status.error_code());
+  EXPECT_EQ(::grpc::CANCELLED, status.error_code());
 
   EXPECT_TRUE(cancelled.get());
 }
+
+} // namespace
+} // namespace eventuals::grpc::test

--- a/test/grpc/cancelled-by-server.cc
+++ b/test/grpc/cancelled-by-server.cc
@@ -13,15 +13,8 @@ using helloworld::HelloRequest;
 
 using stout::Borrowable;
 
-using eventuals::Head;
-using eventuals::Let;
-using eventuals::Terminate;
-using eventuals::Then;
-
-using eventuals::grpc::Client;
-using eventuals::grpc::CompletionPool;
-using eventuals::grpc::Server;
-using eventuals::grpc::ServerBuilder;
+namespace eventuals::grpc::test {
+namespace {
 
 TEST(CancelledByServerTest, Cancelled) {
   ServerBuilder builder;
@@ -30,7 +23,7 @@ TEST(CancelledByServerTest, Cancelled) {
 
   builder.AddListeningPort(
       "0.0.0.0:0",
-      grpc::InsecureServerCredentials(),
+      ::grpc::InsecureServerCredentials(),
       &port);
 
   auto build = builder.BuildAndStart();
@@ -58,7 +51,7 @@ TEST(CancelledByServerTest, Cancelled) {
 
   Client client(
       "0.0.0.0:" + std::to_string(port),
-      grpc::InsecureChannelCredentials(),
+      ::grpc::InsecureChannelCredentials(),
       pool.Borrow());
 
   ::grpc::ClientContext context;
@@ -73,7 +66,10 @@ TEST(CancelledByServerTest, Cancelled) {
 
   auto status = *call();
 
-  EXPECT_EQ(grpc::CANCELLED, status.error_code());
+  EXPECT_EQ(::grpc::CANCELLED, status.error_code());
 
   EXPECT_TRUE(cancelled.get());
 }
+
+} // namespace
+} // namespace eventuals::grpc::test

--- a/test/grpc/client-death-test.cc
+++ b/test/grpc/client-death-test.cc
@@ -12,17 +12,12 @@
 #include "test/grpc/death-constants.h"
 #include "test/grpc/test.h"
 
+namespace eventuals::grpc::test {
+namespace {
+
 using helloworld::Greeter;
 using helloworld::HelloReply;
 using helloworld::HelloRequest;
-
-using eventuals::Head;
-using eventuals::Let;
-using eventuals::Terminate;
-using eventuals::Then;
-
-using eventuals::grpc::Server;
-using eventuals::grpc::ServerBuilder;
 
 // Tests that servers correctly handle clients that disconnect before sending a
 // request.
@@ -34,7 +29,7 @@ TEST(ClientDeathTest, ServerHandlesClientDisconnect) {
 
   builder.AddListeningPort(
       "0.0.0.0:0",
-      grpc::InsecureServerCredentials(),
+      ::grpc::InsecureServerCredentials(),
       &port);
 
   auto build = builder.BuildAndStart();
@@ -66,7 +61,10 @@ TEST(ClientDeathTest, ServerHandlesClientDisconnect) {
   const int result = std::system(command.c_str());
   // Issue(#329): WEXITSTATUS is Posix-specific. Figure out the correct way
   // to get the application's return code on windows.
-  EXPECT_EQ(eventuals::grpc::kProcessIntentionalExitCode, WEXITSTATUS(result));
+  EXPECT_EQ(kProcessIntentionalExitCode, WEXITSTATUS(result));
 
   EXPECT_TRUE(cancelled.get());
 }
+
+} // namespace
+} // namespace eventuals::grpc::test

--- a/test/grpc/deadline.cc
+++ b/test/grpc/deadline.cc
@@ -9,22 +9,14 @@
 #include "gtest/gtest.h"
 #include "test/grpc/test.h"
 
+namespace eventuals::grpc::test {
+namespace {
+
 using helloworld::Greeter;
 using helloworld::HelloReply;
 using helloworld::HelloRequest;
 
 using stout::Borrowable;
-
-using eventuals::Closure;
-using eventuals::Head;
-using eventuals::Let;
-using eventuals::Terminate;
-using eventuals::Then;
-
-using eventuals::grpc::Client;
-using eventuals::grpc::CompletionPool;
-using eventuals::grpc::Server;
-using eventuals::grpc::ServerBuilder;
 
 TEST(DeadlineTest, DeadlineExceeded) {
   ServerBuilder builder;
@@ -33,7 +25,7 @@ TEST(DeadlineTest, DeadlineExceeded) {
 
   builder.AddListeningPort(
       "0.0.0.0:0",
-      grpc::InsecureServerCredentials(),
+      ::grpc::InsecureServerCredentials(),
       &port);
 
   auto build = builder.BuildAndStart();
@@ -60,7 +52,7 @@ TEST(DeadlineTest, DeadlineExceeded) {
 
   Client client(
       "0.0.0.0:" + std::to_string(port),
-      grpc::InsecureChannelCredentials(),
+      ::grpc::InsecureChannelCredentials(),
       pool.Borrow());
 
   auto call = [&]() {
@@ -83,7 +75,10 @@ TEST(DeadlineTest, DeadlineExceeded) {
 
   auto status = *call();
 
-  ASSERT_EQ(grpc::DEADLINE_EXCEEDED, status.error_code());
+  ASSERT_EQ(::grpc::DEADLINE_EXCEEDED, status.error_code());
 
   ASSERT_TRUE(cancelled.get());
 }
+
+} // namespace
+} // namespace eventuals::grpc::test

--- a/test/grpc/death-client.cc
+++ b/test/grpc/death-client.cc
@@ -4,34 +4,35 @@
 #include "examples/protos/helloworld.grpc.pb.h"
 #include "test/grpc/death-constants.h"
 
+namespace eventuals::grpc::test {
+namespace {
+
 using helloworld::Greeter;
 using helloworld::HelloReply;
 using helloworld::HelloRequest;
 
 using stout::Borrowable;
 
-using eventuals::Then;
-
-using eventuals::grpc::Client;
-using eventuals::grpc::CompletionPool;
-
 void RunClient(const int port) {
   Borrowable<CompletionPool> pool;
 
   Client client(
       "0.0.0.0:" + std::to_string(port),
-      grpc::InsecureChannelCredentials(),
+      ::grpc::InsecureChannelCredentials(),
       pool.Borrow());
 
   auto call = [&]() {
     return client.Call<Greeter, HelloRequest, HelloReply>("SayHello")
         | Then([](auto&& call) {
-             exit(eventuals::grpc::kProcessIntentionalExitCode);
+             exit(kProcessIntentionalExitCode);
            });
   };
 
   *call();
 }
+
+} // namespace
+} // namespace eventuals::grpc::test
 
 // Should only be run from tests!
 //
@@ -46,6 +47,6 @@ int main(int argc, char** argv) {
 
   int port = atoi(argv[1]);
 
-  RunClient(port);
+  ::eventuals::grpc::test::RunClient(port);
   return 0;
 }

--- a/test/grpc/death-constants.h
+++ b/test/grpc/death-constants.h
@@ -1,10 +1,12 @@
 // Shared constants used by tests that run binaries that intentionally die.
 
-namespace eventuals::grpc {
+namespace eventuals::grpc::test {
+
 // The exit code issued by a process when dying intentionally. The code number
 // is an arbitrary value that is unlikely to be produced by any other type of
 // unexpected failure (e.g. a CHECK failure). This lets us be confident that
 // tests that run binaries that die with this exit code are dying in an
 // expected way and location.
 constexpr int kProcessIntentionalExitCode = 17;
-} // namespace eventuals::grpc
+
+} // namespace eventuals::grpc::test

--- a/test/grpc/death-server.cc
+++ b/test/grpc/death-server.cc
@@ -5,16 +5,12 @@
 #include "examples/protos/helloworld.grpc.pb.h"
 #include "test/grpc/death-constants.h"
 
+namespace eventuals::grpc::test {
+namespace {
+
 using helloworld::Greeter;
 using helloworld::HelloReply;
 using helloworld::HelloRequest;
-
-using eventuals::Head;
-using eventuals::Terminate;
-using eventuals::Then;
-
-using eventuals::grpc::Server;
-using eventuals::grpc::ServerBuilder;
 
 void RunServer(const int pipe) {
   auto SendPort = [&](int port) {
@@ -27,7 +23,7 @@ void RunServer(const int pipe) {
 
   builder.AddListeningPort(
       "0.0.0.0:0",
-      grpc::InsecureServerCredentials(),
+      ::grpc::InsecureServerCredentials(),
       &port);
 
   auto build = builder.BuildAndStart();
@@ -42,7 +38,7 @@ void RunServer(const int pipe) {
     return server->Accept<Greeter, HelloRequest, HelloReply>("SayHello")
         | Head()
         | Then([](auto&& call) {
-             exit(eventuals::grpc::kProcessIntentionalExitCode);
+             exit(kProcessIntentionalExitCode);
            });
   };
 
@@ -56,6 +52,9 @@ void RunServer(const int pipe) {
 
   future.get();
 }
+
+} // namespace
+} // namespace eventuals::grpc::test
 
 // Should only be run from tests!
 //
@@ -72,6 +71,6 @@ int main(int argc, char** argv) {
 
   int pipe = atoi(argv[1]);
 
-  RunServer(pipe);
+  ::eventuals::grpc::test::RunServer(pipe);
   return 0;
 }

--- a/test/grpc/greeter-server.cc
+++ b/test/grpc/greeter-server.cc
@@ -8,21 +8,15 @@
 #include "test/grpc/helloworld.eventuals.h"
 #include "test/grpc/test.h"
 
-using stout::Borrowable;
-
-using eventuals::Let;
-using eventuals::Loop;
-using eventuals::Map;
-using eventuals::Then;
-
-using eventuals::grpc::Client;
-using eventuals::grpc::CompletionPool;
-using eventuals::grpc::ServerBuilder;
+namespace eventuals::grpc::test {
+namespace {
 
 using helloworld::HelloReply;
 using helloworld::HelloRequest;
 
 using helloworld::eventuals::Greeter;
+
+using stout::Borrowable;
 
 class GreeterServiceImpl final : public Greeter::Service<GreeterServiceImpl> {
  public:
@@ -44,7 +38,7 @@ TEST(GreeterServerTest, SayHello) {
 
   builder.AddListeningPort(
       "0.0.0.0:0",
-      grpc::InsecureServerCredentials(),
+      ::grpc::InsecureServerCredentials(),
       &port);
 
   builder.RegisterService(&service);
@@ -61,7 +55,7 @@ TEST(GreeterServerTest, SayHello) {
 
   Client client(
       "0.0.0.0:" + std::to_string(port),
-      grpc::InsecureChannelCredentials(),
+      ::grpc::InsecureChannelCredentials(),
       pool.Borrow());
 
   auto call = [&]() {
@@ -83,3 +77,6 @@ TEST(GreeterServerTest, SayHello) {
 
   EXPECT_TRUE(status.ok());
 }
+
+} // namespace
+} // namespace eventuals::grpc::test

--- a/test/grpc/main.cc
+++ b/test/grpc/main.cc
@@ -3,14 +3,16 @@
 #include "test/grpc/test.h"
 #include "tools/cpp/runfiles/runfiles.h"
 
-////////////////////////////////////////////////////////////////////////
+namespace {
 
 // NOTE: using a raw pointer here as per Google C++ Style Guide
 // because 'bazel::tools::cpp::runfiles::Runfiles' is not trivially
 // destructible.
 static bazel::tools::cpp::runfiles::Runfiles* runfiles = nullptr;
 
-////////////////////////////////////////////////////////////////////////
+} // namespace
+
+namespace eventuals::grpc::test {
 
 // Declared in test.h.
 std::filesystem::path GetRunfilePathFor(const std::filesystem::path& runfile) {
@@ -21,7 +23,7 @@ std::filesystem::path GetRunfilePathFor(const std::filesystem::path& runfile) {
   return path;
 }
 
-////////////////////////////////////////////////////////////////////////
+} // namespace eventuals::grpc::test
 
 int main(int argc, char** argv) {
   std::string error;
@@ -47,5 +49,3 @@ int main(int argc, char** argv) {
 
   return RUN_ALL_TESTS();
 }
-
-////////////////////////////////////////////////////////////////////////

--- a/test/grpc/multiple-hosts.cc
+++ b/test/grpc/multiple-hosts.cc
@@ -8,21 +8,14 @@
 #include "gtest/gtest.h"
 #include "test/grpc/test.h"
 
+namespace eventuals::grpc::test {
+namespace {
+
 using helloworld::Greeter;
 using helloworld::HelloReply;
 using helloworld::HelloRequest;
 
 using stout::Borrowable;
-
-using eventuals::Head;
-using eventuals::Let;
-using eventuals::Terminate;
-using eventuals::Then;
-
-using eventuals::grpc::Client;
-using eventuals::grpc::CompletionPool;
-using eventuals::grpc::Server;
-using eventuals::grpc::ServerBuilder;
 
 TEST(MultipleHostsTest, Success) {
   ServerBuilder builder;
@@ -31,7 +24,7 @@ TEST(MultipleHostsTest, Success) {
 
   builder.AddListeningPort(
       "0.0.0.0:0",
-      grpc::InsecureServerCredentials(),
+      ::grpc::InsecureServerCredentials(),
       &port);
 
   auto build = builder.BuildAndStart();
@@ -70,7 +63,7 @@ TEST(MultipleHostsTest, Success) {
 
   Client client(
       "0.0.0.0:" + std::to_string(port),
-      grpc::InsecureChannelCredentials(),
+      ::grpc::InsecureChannelCredentials(),
       pool.Borrow());
 
   auto call = [&](auto&& host) {
@@ -97,3 +90,6 @@ TEST(MultipleHostsTest, Success) {
 
   EXPECT_FALSE(washington_cancelled.get());
 }
+
+} // namespace
+} // namespace eventuals::grpc::test

--- a/test/grpc/server-death-test.cc
+++ b/test/grpc/server-death-test.cc
@@ -15,21 +15,14 @@
 #include "test/grpc/death-constants.h"
 #include "test/grpc/test.h"
 
+namespace eventuals::grpc::test {
+namespace {
+
 using helloworld::Greeter;
 using helloworld::HelloReply;
 using helloworld::HelloRequest;
 
 using stout::Borrowable;
-
-using eventuals::Finally;
-using eventuals::Let;
-using eventuals::Then;
-using eventuals::grpc::ClientCall;
-
-using eventuals::grpc::Client;
-using eventuals::grpc::CompletionPool;
-using eventuals::grpc::Server;
-using eventuals::grpc::ServerBuilder;
 
 // Tests that the client receives a ::grpc::UNAVAILABLE status if the server
 // dies without cleanly calling call.Finish().
@@ -56,9 +49,7 @@ TEST(ServerDeathTest, ClientReceivesUnavailable) {
     const int result = std::system(command.c_str());
     // Issue(#329): WEXITSTATUS is Posix-specific. Figure out the correct way
     // to get the application's return code on windows.
-    EXPECT_EQ(
-        eventuals::grpc::kProcessIntentionalExitCode,
-        WEXITSTATUS(result));
+    EXPECT_EQ(kProcessIntentionalExitCode, WEXITSTATUS(result));
   });
 
   int port = WaitForPort();
@@ -67,7 +58,7 @@ TEST(ServerDeathTest, ClientReceivesUnavailable) {
 
   Client client(
       "0.0.0.0:" + std::to_string(port),
-      grpc::InsecureChannelCredentials(),
+      ::grpc::InsecureChannelCredentials(),
       pool.Borrow());
 
   auto call = [&]() {
@@ -91,3 +82,6 @@ TEST(ServerDeathTest, ClientReceivesUnavailable) {
   close(pipefds[0]);
   close(pipefds[1]);
 }
+
+} // namespace
+} // namespace eventuals::grpc::test

--- a/test/grpc/server-unavailable.cc
+++ b/test/grpc/server-unavailable.cc
@@ -6,17 +6,14 @@
 #include "test/expect-throw-what.h"
 #include "test/grpc/test.h"
 
+namespace eventuals::grpc::test {
+namespace {
+
 using helloworld::Greeter;
 using helloworld::HelloReply;
 using helloworld::HelloRequest;
 
 using stout::Borrowable;
-
-using eventuals::Let;
-
-using eventuals::grpc::Client;
-using eventuals::grpc::CompletionPool;
-using eventuals::grpc::Stream;
 
 TEST(ServerUnavailableTest, NonexistantServer) {
   Borrowable<CompletionPool> pool;
@@ -25,7 +22,7 @@ TEST(ServerUnavailableTest, NonexistantServer) {
   // path that should never have a server listening on for this test.
   Client client(
       "unix:eventuals-grpc-test-server-unavailable-" + std::to_string(getpid()),
-      grpc::InsecureChannelCredentials(),
+      ::grpc::InsecureChannelCredentials(),
       pool.Borrow());
 
   auto call = [&]() {
@@ -37,3 +34,6 @@ TEST(ServerUnavailableTest, NonexistantServer) {
 
   EXPECT_THROW_WHAT(*call(), "Failed to start call");
 }
+
+} // namespace
+} // namespace eventuals::grpc::test

--- a/test/grpc/streaming.cc
+++ b/test/grpc/streaming.cc
@@ -11,22 +11,10 @@
 #include "gtest/gtest.h"
 #include "test/grpc/test.h"
 
+namespace eventuals::grpc::test {
+namespace {
+
 using stout::Borrowable;
-
-using eventuals::Closure;
-using eventuals::Head;
-using eventuals::Iterate;
-using eventuals::Let;
-using eventuals::Loop;
-using eventuals::Map;
-using eventuals::Terminate;
-using eventuals::Then;
-
-using eventuals::grpc::Client;
-using eventuals::grpc::CompletionPool;
-using eventuals::grpc::Server;
-using eventuals::grpc::ServerBuilder;
-using eventuals::grpc::Stream;
 
 // We can vary the usage of the streaming API on three dimensions, each of which
 // leads to different concurrency situations in `client.h`:
@@ -56,7 +44,7 @@ void test_client_behavior(Handler handler) {
 
   builder.AddListeningPort(
       "0.0.0.0:0",
-      grpc::InsecureServerCredentials(),
+      ::grpc::InsecureServerCredentials(),
       &port);
 
   auto build = builder.BuildAndStart();
@@ -102,7 +90,7 @@ void test_client_behavior(Handler handler) {
 
   Client client(
       "0.0.0.0:" + std::to_string(port),
-      grpc::InsecureChannelCredentials(),
+      ::grpc::InsecureChannelCredentials(),
       pool.Borrow());
 
   auto call = [&]() {
@@ -369,3 +357,6 @@ TEST(StreamingTest, WritesDone_BeforeReply_TwoRequests) {
             | call.Finish();
       })));
 }
+
+} // namespace
+} // namespace eventuals::grpc::test

--- a/test/grpc/test.h
+++ b/test/grpc/test.h
@@ -2,8 +2,12 @@
 
 #include <filesystem>
 
+namespace eventuals::grpc::test {
+
 // Helper which returns a path for the specified runfile. This is a
 // wrapper around 'bazel::tools::cpp::runfiles::Runfiles' which
 // amongst other things uses 'std::filesystem::path' instead of just
 // 'std::string'.
 std::filesystem::path GetRunfilePathFor(const std::filesystem::path& runfile);
+
+} // namespace eventuals::grpc::test

--- a/test/grpc/unary.cc
+++ b/test/grpc/unary.cc
@@ -9,24 +9,14 @@
 #include "gtest/gtest.h"
 #include "test/grpc/test.h"
 
+namespace eventuals::grpc::test {
+namespace {
+
 using helloworld::Greeter;
 using helloworld::HelloReply;
 using helloworld::HelloRequest;
 
 using stout::Borrowable;
-
-using eventuals::Head;
-using eventuals::Let;
-using eventuals::Loop;
-using eventuals::Map;
-using eventuals::Terminate;
-using eventuals::Then;
-
-using eventuals::grpc::Client;
-using eventuals::grpc::CompletionPool;
-using eventuals::grpc::Server;
-using eventuals::grpc::ServerBuilder;
-using eventuals::grpc::ServerCall;
 
 TEST(UnaryTest, Success) {
   ServerBuilder builder;
@@ -35,7 +25,7 @@ TEST(UnaryTest, Success) {
 
   builder.AddListeningPort(
       "0.0.0.0:0",
-      grpc::InsecureServerCredentials(),
+      ::grpc::InsecureServerCredentials(),
       &port);
 
   auto build = builder.BuildAndStart();
@@ -70,7 +60,7 @@ TEST(UnaryTest, Success) {
 
   Client client(
       "0.0.0.0:" + std::to_string(port),
-      grpc::InsecureChannelCredentials(),
+      ::grpc::InsecureChannelCredentials(),
       pool.Borrow());
 
   auto call = [&]() {
@@ -100,3 +90,6 @@ TEST(UnaryTest, Success) {
   server->Shutdown();
   server->Wait();
 }
+
+} // namespace
+} // namespace eventuals::grpc::test

--- a/test/grpc/unimplemented.cc
+++ b/test/grpc/unimplemented.cc
@@ -5,17 +5,14 @@
 #include "gtest/gtest.h"
 #include "test/grpc/test.h"
 
+namespace eventuals::grpc::test {
+namespace {
+
 using helloworld::Greeter;
 using helloworld::HelloReply;
 using helloworld::HelloRequest;
 
 using stout::Borrowable;
-
-using eventuals::Let;
-
-using eventuals::grpc::Client;
-using eventuals::grpc::CompletionPool;
-using eventuals::grpc::ServerBuilder;
 
 TEST(UnimplementedTest, ClientCallsUnimplementedServerMethod) {
   ServerBuilder builder;
@@ -24,7 +21,7 @@ TEST(UnimplementedTest, ClientCallsUnimplementedServerMethod) {
 
   builder.AddListeningPort(
       "0.0.0.0:0",
-      grpc::InsecureServerCredentials(),
+      ::grpc::InsecureServerCredentials(),
       &port);
 
   auto build = builder.BuildAndStart();
@@ -39,7 +36,7 @@ TEST(UnimplementedTest, ClientCallsUnimplementedServerMethod) {
 
   Client client(
       "0.0.0.0:" + std::to_string(port),
-      grpc::InsecureChannelCredentials(),
+      ::grpc::InsecureChannelCredentials(),
       pool.Borrow());
 
   auto call = [&]() {
@@ -51,5 +48,8 @@ TEST(UnimplementedTest, ClientCallsUnimplementedServerMethod) {
 
   auto status = *call();
 
-  ASSERT_EQ(grpc::UNIMPLEMENTED, status.error_code());
+  ASSERT_EQ(::grpc::UNIMPLEMENTED, status.error_code());
 }
+
+} // namespace
+} // namespace eventuals::grpc::test

--- a/test/http-mock-server.cc
+++ b/test/http-mock-server.cc
@@ -12,6 +12,7 @@
 #include "eventuals/x509.h"
 #include "gtest/gtest.h"
 
+namespace eventuals::http::test {
 namespace {
 
 constexpr static size_t kBufferSize = 4096;
@@ -274,3 +275,5 @@ void HttpMockServer::Accept() {
         }
       });
 }
+
+} // namespace eventuals::http::test

--- a/test/http-mock-server.h
+++ b/test/http-mock-server.h
@@ -11,7 +11,7 @@
 #include "eventuals/x509.h"
 #include "gmock/gmock.h"
 
-////////////////////////////////////////////////////////////////////////
+namespace eventuals::http::test {
 
 // Provides an HTTP mock server. See existing tests for examples of
 // how you can use 'EXPECT_CALL()' on methods like 'ReceivedHeaders()'
@@ -21,6 +21,7 @@
 //
 // NOTE: this class is only expected to be used in tests so it
 // generously uses macros like 'EXPECT_*' and 'ADD_FAILURE'.
+// TODO(alexmc): Move all method definitions into a separate .cc file.
 class HttpMockServer final {
  public:
   // Abstracts whether or not we have a secure, i.e., TLS/SSL, socket
@@ -94,4 +95,4 @@ class HttpMockServer final {
   std::thread thread_;
 };
 
-////////////////////////////////////////////////////////////////////////
+} // namespace eventuals::http::test

--- a/test/iterate.cc
+++ b/test/iterate.cc
@@ -18,11 +18,8 @@
 #include "eventuals/then.h"
 #include "gtest/gtest.h"
 
-using eventuals::Iterate;
-using eventuals::Loop;
-using eventuals::Map;
-using eventuals::Reduce;
-using eventuals::Then;
+namespace eventuals::test {
+namespace {
 
 TEST(Iterate, VectorLvalue) {
   std::vector<int> v = {5, 12};
@@ -808,3 +805,6 @@ TEST(Iterate, UniquePtr) {
 
   EXPECT_EQ(5, *s());
 }
+
+} // namespace
+} // namespace eventuals::test

--- a/test/just.cc
+++ b/test/just.cc
@@ -7,8 +7,8 @@
 #include "eventuals/then.h"
 #include "gtest/gtest.h"
 
-using eventuals::Just;
-using eventuals::Then;
+namespace eventuals::test {
+namespace {
 
 TEST(JustTest, Value) {
   auto e = []() {
@@ -65,3 +65,6 @@ TEST(JustTest, ConstRef) {
 
   EXPECT_EQ(42, future.get());
 }
+
+} // namespace
+} // namespace eventuals::test

--- a/test/let.cc
+++ b/test/let.cc
@@ -8,11 +8,8 @@
 #include "eventuals/timer.h"
 #include "gtest/gtest.h"
 
-using eventuals::EventLoop;
-using eventuals::Just;
-using eventuals::Let;
-using eventuals::Then;
-using eventuals::Timer;
+namespace eventuals::test {
+namespace {
 
 class LetTest : public EventLoopTest {};
 
@@ -42,3 +39,6 @@ TEST_F(LetTest, Let) {
 
   EXPECT_EQ(42, future.get());
 }
+
+} // namespace
+} // namespace eventuals::test

--- a/test/lock.cc
+++ b/test/lock.cc
@@ -13,23 +13,8 @@
 #include "gtest/gtest.h"
 #include "test/expect-throw-what.h"
 
-using eventuals::Acquire;
-using eventuals::Callback;
-using eventuals::ConditionVariable;
-using eventuals::Eventual;
-using eventuals::If;
-using eventuals::Interrupt;
-using eventuals::Iterate;
-using eventuals::Just;
-using eventuals::Lock;
-using eventuals::Map;
-using eventuals::Reduce;
-using eventuals::Release;
-using eventuals::Scheduler;
-using eventuals::Synchronizable;
-using eventuals::Terminate;
-using eventuals::Then;
-using eventuals::Wait;
+namespace eventuals::test {
+namespace {
 
 using testing::MockFunction;
 
@@ -423,3 +408,6 @@ TEST(LockTest, ConditionVariable_UseAfterFree) {
   // eventual to be queued up, this will blow up.
   *foo.NotifyAll();
 }
+
+} // namespace
+} // namespace eventuals::test

--- a/test/pipe.cc
+++ b/test/pipe.cc
@@ -8,8 +8,8 @@
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
-using eventuals::Collect;
-using eventuals::Pipe;
+namespace eventuals::test {
+namespace {
 
 using testing::ElementsAre;
 
@@ -84,3 +84,6 @@ TEST(Pipe, Size) {
       *e(),
       ElementsAre(std::string{"Hello"}, std::string{" world!"}));
 }
+
+} // namespace
+} // namespace eventuals::test

--- a/test/poll.cc
+++ b/test/poll.cc
@@ -14,17 +14,8 @@
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
-using eventuals::DoAll;
-using eventuals::EventLoop;
-using eventuals::Interrupt;
-using eventuals::Loop;
-using eventuals::Map;
-using eventuals::Poll;
-using eventuals::PollEvents;
-using eventuals::Reduce;
-using eventuals::Then;
-using eventuals::Unpack;
-using eventuals::Until;
+namespace eventuals::test {
+namespace {
 
 class PollTest : public EventLoopTest {};
 
@@ -108,3 +99,6 @@ TEST_F(PollTest, Succeed) {
 
   EXPECT_EQ(data1 + data2, future.get());
 }
+
+} // namespace
+} // namespace eventuals::test

--- a/test/range.cc
+++ b/test/range.cc
@@ -7,8 +7,8 @@
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
-using eventuals::Collect;
-using eventuals::Range;
+namespace eventuals::test {
+namespace {
 
 using testing::ElementsAre;
 
@@ -88,3 +88,6 @@ TEST(Range, SpecifiedStepNegative) {
 
   EXPECT_THAT(*s, ElementsAre(0, -2, -4, -6, -8));
 }
+
+} // namespace
+} // namespace eventuals::test

--- a/test/repeat.cc
+++ b/test/repeat.cc
@@ -11,18 +11,8 @@
 #include "gtest/gtest.h"
 #include "test/expect-throw-what.h"
 
-using eventuals::Acquire;
-using eventuals::Eventual;
-using eventuals::Interrupt;
-using eventuals::Lock;
-using eventuals::Loop;
-using eventuals::Map;
-using eventuals::Reduce;
-using eventuals::Release;
-using eventuals::Repeat;
-using eventuals::Terminate;
-using eventuals::Then;
-using eventuals::Until;
+namespace eventuals::test {
+namespace {
 
 using testing::MockFunction;
 
@@ -198,3 +188,6 @@ TEST(RepeatTest, MapAcquire) {
 
   EXPECT_EQ(5, *r());
 }
+
+} // namespace
+} // namespace eventuals::test

--- a/test/signal.cc
+++ b/test/signal.cc
@@ -11,14 +11,8 @@
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
-using eventuals::EventLoop;
-using eventuals::Eventual;
-using eventuals::Interrupt;
-using eventuals::Scheduler;
-using eventuals::Terminate;
-using eventuals::Then;
-using eventuals::WaitForOneOfSignals;
-using eventuals::WaitForSignal;
+namespace eventuals::test {
+namespace {
 
 // Windows notes!
 //
@@ -109,3 +103,6 @@ TEST_F(SignalTest, SignalInterrupt) {
 
   EXPECT_THROW(future.get(), eventuals::StoppedException);
 }
+
+} // namespace
+} // namespace eventuals::test

--- a/test/static-thread-pool.cc
+++ b/test/static-thread-pool.cc
@@ -18,20 +18,8 @@
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
-using eventuals::Closure;
-using eventuals::Collect;
-using eventuals::Concurrent;
-using eventuals::Eventual;
-using eventuals::Iterate;
-using eventuals::Let;
-using eventuals::Loop;
-using eventuals::Map;
-using eventuals::Pinned;
-using eventuals::Repeat;
-using eventuals::Scheduler;
-using eventuals::StaticThreadPool;
-using eventuals::Then;
-using eventuals::Until;
+namespace eventuals::test {
+namespace {
 
 using testing::UnorderedElementsAre;
 
@@ -234,3 +222,6 @@ TEST(StaticThreadPoolTest, Concurrent) {
 
   EXPECT_THAT(*e(), UnorderedElementsAre(1, 2, 3));
 }
+
+} // namespace
+} // namespace eventuals::test

--- a/test/stream.cc
+++ b/test/stream.cc
@@ -14,17 +14,8 @@
 #include "gtest/gtest.h"
 #include "test/expect-throw-what.h"
 
-using eventuals::Eventual;
-using eventuals::Head;
-using eventuals::Interrupt;
-using eventuals::Lazy;
-using eventuals::Loop;
-using eventuals::Map;
-using eventuals::Raise;
-using eventuals::Reduce;
-using eventuals::Stream;
-using eventuals::Terminate;
-using eventuals::Then;
+namespace eventuals::test {
+namespace {
 
 using testing::MockFunction;
 
@@ -493,3 +484,6 @@ TEST(StreamTest, ThrowGeneralError) {
 
   EXPECT_THROW_WHAT(*e(), "error");
 }
+
+} // namespace
+} // namespace eventuals::test

--- a/test/take.cc
+++ b/test/take.cc
@@ -9,12 +9,8 @@
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
-using eventuals::Collect;
-using eventuals::Filter;
-using eventuals::Iterate;
-using eventuals::TakeFirstN;
-using eventuals::TakeLastN;
-using eventuals::TakeRange;
+namespace eventuals::test {
+namespace {
 
 using testing::ElementsAre;
 
@@ -162,3 +158,6 @@ TEST(Take, UniquePtr) {
   EXPECT_EQ(1, *result[0]);
   EXPECT_EQ(2, *result[1]);
 }
+
+} // namespace
+} // namespace eventuals::test

--- a/test/task.cc
+++ b/test/task.cc
@@ -12,12 +12,8 @@
 #include "gtest/gtest.h"
 #include "test/expect-throw-what.h"
 
-using eventuals::Eventual;
-using eventuals::Interrupt;
-using eventuals::Just;
-using eventuals::Map;
-using eventuals::Task;
-using eventuals::Then;
+namespace eventuals::test {
+namespace {
 
 using testing::MockFunction;
 
@@ -644,3 +640,6 @@ TEST(Task, RaisesWith) {
 
   EXPECT_EQ(42, *e());
 }
+
+} // namespace
+} // namespace eventuals::test

--- a/test/then.cc
+++ b/test/then.cc
@@ -8,11 +8,8 @@
 #include "gtest/gtest.h"
 #include "test/expect-throw-what.h"
 
-using eventuals::Eventual;
-using eventuals::Interrupt;
-using eventuals::Just;
-using eventuals::Terminate;
-using eventuals::Then;
+namespace eventuals::test {
+namespace {
 
 using testing::MockFunction;
 
@@ -130,3 +127,6 @@ TEST(ThenTest, Interrupt) {
 
   EXPECT_THROW(future.get(), eventuals::StoppedException);
 }
+
+} // namespace
+} // namespace eventuals::test

--- a/test/timer.cc
+++ b/test/timer.cc
@@ -8,14 +8,8 @@
 #include "eventuals/terminal.h"
 #include "gtest/gtest.h"
 
-using eventuals::Clock;
-using eventuals::EventLoop;
-using eventuals::Foreach;
-using eventuals::Interrupt;
-using eventuals::Just;
-using eventuals::Range;
-using eventuals::Terminate;
-using eventuals::Timer;
+namespace eventuals::test {
+namespace {
 
 TEST_F(EventLoopTest, Timer) {
   auto e = []() {
@@ -190,3 +184,6 @@ TEST_F(EventLoopTest, MapTimer) {
 
   EXPECT_LE(std::chrono::milliseconds(10), end - start);
 }
+
+} // namespace
+} // namespace eventuals::test

--- a/test/transformer.cc
+++ b/test/transformer.cc
@@ -14,14 +14,8 @@
 #include "gtest/gtest.h"
 #include "test/expect-throw-what.h"
 
-using eventuals::Collect;
-using eventuals::Eventual;
-using eventuals::Interrupt;
-using eventuals::Iterate;
-using eventuals::Let;
-using eventuals::Map;
-using eventuals::Stream;
-using eventuals::Transformer;
+namespace eventuals::test {
+namespace {
 
 using testing::ElementsAre;
 using testing::MockFunction;
@@ -241,3 +235,6 @@ TEST(Transformer, PropagateFail) {
 
   EXPECT_THROW_WHAT(*e(), "error");
 }
+
+} // namespace
+} // namespace eventuals::test

--- a/test/type-check.cc
+++ b/test/type-check.cc
@@ -7,9 +7,8 @@
 #include "eventuals/terminal.h"
 #include "gtest/gtest.h"
 
-using eventuals::Collect;
-using eventuals::Iterate;
-using eventuals::TypeCheck;
+namespace eventuals::test {
+namespace {
 
 TEST(TypeCheck, Lvalue) {
   std::vector<int> v = {5, 12};
@@ -31,3 +30,6 @@ TEST(TypeCheck, Rvalue) {
 
   EXPECT_EQ(std::vector<int>({5, 12}), *s());
 }
+
+} // namespace
+} // namespace eventuals::test

--- a/test/type-traits.cc
+++ b/test/type-traits.cc
@@ -2,14 +2,8 @@
 
 #include <string>
 
-using eventuals::tuple_types_contains_subtype_v;
-using eventuals::tuple_types_subset_subtype_v;
-using eventuals::tuple_types_subset_v;
-using eventuals::tuple_types_subtract_t;
-using eventuals::tuple_types_union_all_t;
-using eventuals::tuple_types_union_t;
-using eventuals::tuple_types_unordered_equals_v;
-using eventuals::types_contains_v;
+namespace eventuals::test {
+namespace {
 
 ////////////////////////////////////////////////////////////////////////
 
@@ -255,3 +249,6 @@ static_assert(
         std::tuple<B, D>>);
 
 ////////////////////////////////////////////////////////////////////////
+
+} // namespace
+} // namespace eventuals::test

--- a/test/unpack.cc
+++ b/test/unpack.cc
@@ -7,9 +7,8 @@
 #include "eventuals/then.h"
 #include "gtest/gtest.h"
 
-using eventuals::Just;
-using eventuals::Then;
-using eventuals::Unpack;
+namespace eventuals::test {
+namespace {
 
 TEST(Unpack, Unpack) {
   auto e = []() {
@@ -21,3 +20,6 @@ TEST(Unpack, Unpack) {
 
   EXPECT_EQ("42", *e());
 }
+
+} // namespace
+} // namespace eventuals::test


### PR DESCRIPTION
Per https://google.github.io/styleguide/cppguide.html#Namespaces :

> With few exceptions, place code in a namespace.

In addition to making code more style-guide compliant, this reduces
noise by making many `using` statements unnecessary.

Move tests into an unnamed namespace to give them internal linkage:
https://google.github.io/styleguide/cppguide.html#Internal_Linkage

See discussion in https://github.com/3rdparty/eventuals/pull/339
