### PR TITLE
Remove unused using-directives

### DIFF
--- a/test/signal.cc
+++ b/test/signal.cc
@@ -20,8 +20,6 @@ using eventuals::Then;
 using eventuals::WaitForOneOfSignals;
 using eventuals::WaitForSignal;
 
-using namespace std::chrono_literals;
-
 // Windows notes!
 //
 // On Windows calls to raise() or abort() to programmatically

--- a/test/static-thread-pool.cc
+++ b/test/static-thread-pool.cc
@@ -96,8 +96,6 @@ TEST(StaticThreadPoolTest, PingPong) {
       : StaticThreadPool::Schedulable(pinned) {}
 
     auto Stream() {
-      using namespace eventuals;
-
       return Repeat()
           | Until([this]() {
                return Schedule(Then([this]() {
@@ -117,8 +115,6 @@ TEST(StaticThreadPoolTest, PingPong) {
       : StaticThreadPool::Schedulable(pinned) {}
 
     auto Listen() {
-      using namespace eventuals;
-
       return Schedule(Map([this](int i) {
                count++;
                return i;


### PR DESCRIPTION
In addition to being unused, these are discouraged by the style guide:
https://google.github.io/styleguide/cppguide.html#Namespaces
