### PR TITLE
Remove null values from MergeQueue config

### DIFF
--- a/.mergequeue/config.yml
+++ b/.mergequeue/config.yml
@@ -27,8 +27,6 @@ merge_rules:
     max_runs_for_update: 0
   merge_commit:
     use_title_and_body: false
-    cut_body_before: null
-    cut_body_after: null
   merge_strategy:
     name: squash
     override_labels:


### PR DESCRIPTION
As discussed in https://app.shortwave.com/m/msg-53b73f1b-66d7-4055-8402-b2aeb69f0bca MergeQueue currently can't accept configurations with `null` values in them. Removing them is the appropriate fix.