### PR TITLE
Add ServerStatus.ToString() and operator<<

### DIFF
--- a/eventuals/grpc/server.h
+++ b/eventuals/grpc/server.h
@@ -2,6 +2,7 @@
 
 #include <cassert>
 #include <deque>
+#include <string_view>
 #include <thread>
 
 #include "absl/container/flat_hash_map.h"
@@ -497,6 +498,10 @@ class ServerStatus {
     return error_.value();
   }
 
+  std::string_view ToString() const {
+    return ok() ? std::string_view("OK") : std::string_view(error());
+  }
+
  private:
   ServerStatus() {}
   ServerStatus(const std::string& error)
@@ -504,6 +509,10 @@ class ServerStatus {
 
   std::optional<std::string> error_;
 };
+
+inline std::ostream& operator<<(std::ostream& os, const ServerStatus& s) {
+  return os << s.ToString();
+}
 
 ////////////////////////////////////////////////////////////////////////
 


### PR DESCRIPTION
This makes it easier to print bad status messages in tests, so we can
change:

`ASSERT_TRUE(status.ok());`

to:

`ASSERT_TRUE(status.ok()) << status;`

This follows the pattern used by `::absl::Status`:
https://github.com/abseil/abseil-cpp/blob/master/absl/status/status.cc#L316-L319

Note that this is dissimilar to `::grpc::Status` which provides no such
convenience functions:
https://grpc.github.io/grpc/cpp/classgrpc_1_1_status.html
