### PR TITLE
Print bad status details on `ASSERT_TRUE(status)`

### DIFF
--- a/test/grpc/accept.cc
+++ b/test/grpc/accept.cc
@@ -20,7 +20,7 @@ TEST(AcceptTest, ServeValidate) {
 
   auto build = builder.BuildAndStart();
 
-  ASSERT_TRUE(build.status.ok());
+  ASSERT_TRUE(build.status.ok()) << build.status;
 
   auto server = std::move(build.server);
 

--- a/test/grpc/build-and-start.cc
+++ b/test/grpc/build-and-start.cc
@@ -12,7 +12,7 @@ TEST(BuildAndStartTest, Success) {
 
   auto build = builder.BuildAndStart();
 
-  ASSERT_TRUE(build.status.ok());
+  ASSERT_TRUE(build.status.ok()) << build.status;
   ASSERT_TRUE(build.server);
 }
 

--- a/test/grpc/cancelled-by-client.cc
+++ b/test/grpc/cancelled-by-client.cc
@@ -29,7 +29,7 @@ TEST(CancelledByClientTest, Cancelled) {
 
   auto build = builder.BuildAndStart();
 
-  ASSERT_TRUE(build.status.ok());
+  ASSERT_TRUE(build.status.ok()) << build.status;
 
   auto server = std::move(build.server);
 

--- a/test/grpc/cancelled-by-server.cc
+++ b/test/grpc/cancelled-by-server.cc
@@ -29,7 +29,7 @@ TEST(CancelledByServerTest, Cancelled) {
 
   auto build = builder.BuildAndStart();
 
-  ASSERT_TRUE(build.status.ok());
+  ASSERT_TRUE(build.status.ok()) << build.status;
 
   auto server = std::move(build.server);
 

--- a/test/grpc/client-death-test.cc
+++ b/test/grpc/client-death-test.cc
@@ -34,7 +34,7 @@ TEST(ClientDeathTest, ServerHandlesClientDisconnect) {
 
   auto build = builder.BuildAndStart();
 
-  ASSERT_TRUE(build.status.ok());
+  ASSERT_TRUE(build.status.ok()) << build.status;
 
   auto server = std::move(build.server);
 

--- a/test/grpc/deadline.cc
+++ b/test/grpc/deadline.cc
@@ -30,7 +30,7 @@ TEST(DeadlineTest, DeadlineExceeded) {
 
   auto build = builder.BuildAndStart();
 
-  ASSERT_TRUE(build.status.ok());
+  ASSERT_TRUE(build.status.ok()) << build.status;
 
   auto server = std::move(build.server);
 

--- a/test/grpc/greeter-server.cc
+++ b/test/grpc/greeter-server.cc
@@ -45,7 +45,7 @@ TEST(GreeterServerTest, SayHello) {
 
   auto build = builder.BuildAndStart();
 
-  ASSERT_TRUE(build.status.ok());
+  ASSERT_TRUE(build.status.ok()) << build.status;
 
   auto server = std::move(build.server);
 
@@ -75,7 +75,9 @@ TEST(GreeterServerTest, SayHello) {
 
   auto status = *call();
 
-  EXPECT_TRUE(status.ok());
+  EXPECT_TRUE(status.ok()) << status.error_code()
+                           << ": " << status.error_message();
+  ;
 }
 
 } // namespace

--- a/test/grpc/multiple-hosts.cc
+++ b/test/grpc/multiple-hosts.cc
@@ -29,7 +29,7 @@ TEST(MultipleHostsTest, Success) {
 
   auto build = builder.BuildAndStart();
 
-  ASSERT_TRUE(build.status.ok());
+  ASSERT_TRUE(build.status.ok()) << build.status;
 
   auto server = std::move(build.server);
 
@@ -80,13 +80,15 @@ TEST(MultipleHostsTest, Success) {
 
   auto status = *call("cs.berkeley.edu");
 
-  EXPECT_TRUE(status.ok());
+  EXPECT_TRUE(status.ok()) << status.error_code()
+                           << ": " << status.error_message();
 
   EXPECT_FALSE(berkeley_cancelled.get());
 
   status = *call("cs.washington.edu");
 
-  EXPECT_TRUE(status.ok());
+  EXPECT_TRUE(status.ok()) << status.error_code()
+                           << ": " << status.error_message();
 
   EXPECT_FALSE(washington_cancelled.get());
 }

--- a/test/grpc/streaming.cc
+++ b/test/grpc/streaming.cc
@@ -50,7 +50,7 @@ void test_client_behavior(Handler handler) {
 
   auto build = builder.BuildAndStart();
 
-  ASSERT_TRUE(build.status.ok());
+  ASSERT_TRUE(build.status.ok()) << build.status;
 
   auto server = std::move(build.server);
 
@@ -104,7 +104,8 @@ void test_client_behavior(Handler handler) {
 
   auto status = *call();
 
-  EXPECT_TRUE(status.ok()) << status.error_message();
+  EXPECT_TRUE(status.ok()) << status.error_code()
+                           << ": " << status.error_message();
 
   EXPECT_FALSE(cancelled.get());
 }

--- a/test/grpc/unary.cc
+++ b/test/grpc/unary.cc
@@ -31,7 +31,7 @@ TEST(UnaryTest, Success) {
 
   auto build = builder.BuildAndStart();
 
-  ASSERT_TRUE(build.status.ok());
+  ASSERT_TRUE(build.status.ok()) << build.status;
 
   auto server = std::move(build.server);
 
@@ -81,7 +81,8 @@ TEST(UnaryTest, Success) {
 
   auto status = *call();
 
-  EXPECT_TRUE(status.ok());
+  EXPECT_TRUE(status.ok()) << status.error_code()
+                           << ": " << status.error_message();
 
   EXPECT_FALSE(cancelled.get());
 

--- a/test/grpc/unimplemented.cc
+++ b/test/grpc/unimplemented.cc
@@ -26,7 +26,7 @@ TEST(UnimplementedTest, ClientCallsUnimplementedServerMethod) {
 
   auto build = builder.BuildAndStart();
 
-  ASSERT_TRUE(build.status.ok());
+  ASSERT_TRUE(build.status.ok()) << build.status;
 
   auto server = std::move(build.server);
 


### PR DESCRIPTION
When a status is unexpectedly OK, it's easier to debug the problem when
the failure messages includes more details about the bad status.