### PR TITLE
Update curl rules

### DIFF
--- a/3rdparty/bazel-rules-curl/repos.bzl
+++ b/3rdparty/bazel-rules-curl/repos.bzl
@@ -28,7 +28,7 @@ def repos(external = True, repo_mapping = {}):
             git_repository,
             name = "com_github_3rdparty_bazel_rules_curl",
             remote = "https://github.com/3rdparty/bazel-rules-curl",
-            commit = "3c46e684ee629bf2502946ccdd369b1f9d42de08",
-            shallow_since = "1642609159 +0300",
+            commit = "48cf05764bea5fa4a9e539efd837608bbf3a69de",
+            shallow_since = "1651695807 +0200",
             repo_mapping = repo_mapping,
         )


### PR DESCRIPTION
Should be merged after https://github.com/3rdparty/bazel-rules-curl/pull/15.

Fixes #240.