### PR TITLE
Explicitly state which files to use as a source in test/concurrent/BUILD.bazel

### DIFF
--- a/test/concurrent/BUILD.bazel
+++ b/test/concurrent/BUILD.bazel
@@ -9,10 +9,30 @@ cc_library(
     # We've split all of the tests into separate files so they can be
     # compiled in parallel which is significantly faster than having
     # all of the tests in a single file.
-    srcs = glob([
-        "*.cc",
-        "*.h",
-    ]),
+    srcs = [
+        "concurrent.h",
+        "concurrent-downstream-done-both-eventuals-success.cc",
+        "concurrent-downstream-done-one-eventual-fail.cc",
+        "concurrent-downstream-done-one-eventual-stop.cc",
+        "concurrent-emit-fail-interrupt.cc",
+        "concurrent-emit-interrupt-fail.cc",
+        "concurrent-emit-interrupt-stop.cc",
+        "concurrent-emit-stop-interrupt.cc",
+        "concurrent-fail.cc",
+        "concurrent-fail-before-start.cc",
+        "concurrent-fail-or-stop.cc",
+        "concurrent-flat-map.cc",
+        "concurrent-interrupt-fail.cc",
+        "concurrent-interrupt-fail-or-stop.cc",
+        "concurrent-interrupt-stop.cc",
+        "concurrent-interrupt-success.cc",
+        "concurrent-moveable.cc",
+        "concurrent-stop.cc",
+        "concurrent-stop-before-start.cc",
+        "concurrent-stream-fail.cc",
+        "concurrent-stream-stop.cc",
+        "concurrent-success.cc",
+    ],
     copts = copts(),
     visibility = ["//test:__pkg__"],
     deps = [


### PR DESCRIPTION
The reason is simple: glob will never tell you the errors with the filenames that it encountered, while explicit statement will.