### PR TITLE
Use std::chrono::duration::count() as an argument for curl_easy_setopt(CURLOPT_TIMEOUT_MS) AND initialize previously uninitialized variables in http.h

### DIFF
--- a/eventuals/event-loop.h
+++ b/eventuals/event-loop.h
@@ -390,7 +390,7 @@ class EventLoop final : public Scheduler {
         }
 
         stout::borrowed_ref<Clock> clock_;
-        std::chrono::nanoseconds nanoseconds_;
+        std::chrono::nanoseconds nanoseconds_ = std::chrono::nanoseconds(0);
 
         uv_timer_t timer_;
 
@@ -432,7 +432,7 @@ class EventLoop final : public Scheduler {
         }
 
         stout::borrowed_ref<Clock> clock_;
-        std::chrono::nanoseconds nanoseconds_;
+        std::chrono::nanoseconds nanoseconds_ = std::chrono::nanoseconds(0);
       };
     };
 
@@ -440,10 +440,10 @@ class EventLoop final : public Scheduler {
 
     // Stores paused time, no time means clock is not paused.
     std::optional<std::chrono::nanoseconds> paused_;
-    std::chrono::nanoseconds advanced_;
+    std::chrono::nanoseconds advanced_ = std::chrono::nanoseconds(0);
 
     struct Pending final {
-      std::chrono::nanoseconds nanoseconds;
+      std::chrono::nanoseconds nanoseconds = std::chrono::nanoseconds(0);
       Callback<void(const std::chrono::nanoseconds&)> callback;
     };
 

--- a/eventuals/http.h
+++ b/eventuals/http.h
@@ -80,10 +80,10 @@ class Request final {
   class _Builder;
 
   std::string uri_;
-  Method method_;
+  Method method_ = Method::GET;
   Headers headers_;
   std::string body_;
-  std::chrono::nanoseconds timeout_;
+  std::chrono::nanoseconds timeout_ = std::chrono::nanoseconds(0);
   PostFields fields_;
   std::optional<bool> verify_peer_;
   std::optional<x509::Certificate> certificate_;
@@ -313,7 +313,7 @@ struct Response final {
       headers_(std::move(headers)),
       body_(std::move(body)) {}
 
-  long code_;
+  long code_ = 0;
   Headers headers_;
   std::string body_;
 };

--- a/eventuals/http.h
+++ b/eventuals/http.h
@@ -1053,7 +1053,9 @@ struct _HTTP final {
                   curl_easy_setopt(
                       easy_.get(),
                       CURLOPT_TIMEOUT_MS,
-                      duration_cast<milliseconds>(request_.timeout())),
+                      static_cast<long>(duration_cast<milliseconds>(
+                                            request_.timeout())
+                                            .count())),
                   CURLE_OK);
               // If onoff is 1, libcurl will not use any functions that install
               // signal handlers or any functions that cause signals to be sent


### PR DESCRIPTION
Fixes the following error:
```
[ RUN      ] Schemes/HttpTest.GetHeaders/1
F20220428 16:15:13.547349 665984512 http.h:1059] Check failed: curl_easy_setopt(easy_.get(),CURLOPT_TIMEOUT_MS,static_cast<long>( duration_cast<milliseconds>(request_.timeout()) .count())) == CURLE_OK (43 vs. 0) 
```
CURLE code 43 means CURLE_BAD_FUNCTION_ARGUMENT.
If you look into the CURL code:

```
case CURLOPT_TIMEOUT_MS:
    arg = va_arg(param, long);
    if(arg < 0)
      return CURLE_BAD_FUNCTION_ARGUMENT;
    data->set.timeout = arg;
    break;
```

That means that somehow we are getting the negative number as an argument. After digging into it I found several uninitialized variables, e.g. `timeout` variable, which was providing us with a negative value sometimes.

CURLOPT_TIMEOUT_MS also uses `long` as a type for the timeout argument: https://curl.se/libcurl/c/CURLOPT_TIMEOUT_MS.html
Currently we are providing the function with `long long`. It's better to explicitly cast it to `long` by ourselves first.