### PR TITLE
Use 'maybe' with 'submodule_repository'

### DIFF
--- a/bazel/submodules.bzl
+++ b/bazel/submodules.bzl
@@ -1,21 +1,24 @@
 """Bind all submodules needed for eventuals."""
 
+load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe")
 load("@com_github_3rdparty_eventuals//bazel:submodule_repository.bzl", "submodule_repository")
 
-def submodules(external):
+def submodules(external = True):
     """Creates repositories for each submodule.
 
     Args:
           external: whether or not we're invoking this function as though
             though we're an external dependency
     """
-    submodule_repository(
+    maybe(
+        submodule_repository,
         name = "com_github_reboot_dev_pyprotoc_plugin",
         path = "submodules/pyprotoc-plugin",
         external = external,
     )
 
-    submodule_repository(
+    maybe(
+        submodule_repository,
         name = "com_github_3rdparty_stout",
         path = "submodules/stout",
         external = external,


### PR DESCRIPTION
So that others can override the repository if they want!

We also swapped the default to be 'external = True' so that only the
eventuals 'WORKSPACE.bazel' needs to remember to set it to 'False'.