### PR TITLE
Manually update to latest stout

### DIFF
--- a/eventuals/scheduler.cc
+++ b/eventuals/scheduler.cc
@@ -1,7 +1,7 @@
 #include "eventuals/scheduler.h"
 
 #include "glog/logging.h" // For GetTID().
-#include "stout/stringify.hpp"
+#include "stout/stringify.h"
 
 ////////////////////////////////////////////////////////////////////////
 

--- a/eventuals/scheduler.h
+++ b/eventuals/scheduler.h
@@ -15,7 +15,7 @@
 #include "eventuals/terminal.h"
 #include "eventuals/undefined.h"
 #include "stout/borrowable.h"
-#include "stout/stringify.hpp"
+#include "stout/stringify.h"
 
 ////////////////////////////////////////////////////////////////////////
 

--- a/eventuals/task.h
+++ b/eventuals/task.h
@@ -11,7 +11,7 @@
 #include "eventuals/raise.h"
 #include "eventuals/terminal.h"
 #include "eventuals/type-traits.h"
-#include "stout/stringify.hpp"
+#include "stout/stringify.h"
 
 ////////////////////////////////////////////////////////////////////////
 


### PR DESCRIPTION
Include `.h` files rather than `.hpp` files to match the rename in
https://github.com/3rdparty/stout/pull/45

This is a fixed alternative to #400.
