### PR TITLE
Introduce google failure signal handler

### DIFF
--- a/test/BUILD.bazel
+++ b/test/BUILD.bazel
@@ -61,6 +61,8 @@ cc_test(
         "eventual.cc",
         "executor.cc",
         "expected.cc",
+        "failure-signal-handler.cc",
+        "failure-signal-handler.h",
         "filesystem.cc",
         "filter.cc",
         "finally.cc",

--- a/test/failure-signal-handler.cc
+++ b/test/failure-signal-handler.cc
@@ -1,0 +1,8 @@
+#include "failure-signal-handler.h"
+
+// For setting up gtest environment in order to use
+// `glog` failure signal handler:
+// https://github.com/google/glog#failure-signal-handler
+static testing::Environment* const signal_handler_failure_env =
+    testing::AddGlobalTestEnvironment(
+        new InstallFailureSignalHandlerEnvironment{});

--- a/test/failure-signal-handler.h
+++ b/test/failure-signal-handler.h
@@ -1,0 +1,13 @@
+#include "glog/logging.h"
+#include "gtest/gtest.h"
+
+class InstallFailureSignalHandlerEnvironment : public ::testing::Environment {
+ public:
+  ~InstallFailureSignalHandlerEnvironment() override {}
+
+  void SetUp() override {
+    google::InstallFailureSignalHandler();
+  }
+
+  void TearDown() override {}
+};


### PR DESCRIPTION
Earlier we had absolutely horrible stack trace on `glog` check failure, like in example below:
![stack](https://user-images.githubusercontent.com/68085133/169266701-0b73a9a8-e0d0-4ac8-a7d0-468d007ce528.png)

This PR introduces a convenient [signal handler](https://github.com/google/glog#failure-signal-handler) that will dump useful information when the program crashes on certain signals such as SIGSEGV. The signal handler can be installed by `google::InstallFailureSignalHandler()` from `glog` library.