### PR TITLE
Separate base tests from eventuals test target

### DIFF
--- a/bazel/repos.bzl
+++ b/bazel/repos.bzl
@@ -46,8 +46,9 @@ def repos(repo_mapping = {}):
         git_repository,
         name = "com_github_3rdparty_bazel_rules_curl",
         remote = "https://github.com/3rdparty/bazel-rules-curl",
-        commit = "5748da4b2594fab9410db9b5e6619b47cb5688e0",
-        shallow_since = "1651700487 +0300",
+        #commit = "5748da4b2594fab9410db9b5e6619b47cb5688e0",
+        commit = "3daa52e727be203df676e55450153a99da657588",
+        #shallow_since = "1651700487 +0300",
         repo_mapping = repo_mapping,
     )
 

--- a/test/BUILD.bazel
+++ b/test/BUILD.bazel
@@ -27,7 +27,6 @@ cc_library(
 
 cc_library(
     name = "http-mock-server",
-    testonly = True,
     srcs = ["http-mock-server.cc"],
     hdrs = ["http-mock-server.h"],
     copts = copts(),
@@ -38,8 +37,12 @@ cc_library(
     ],
 )
 
-cc_test(
-    name = "eventuals",
+cc_library(
+    name = "base",
+    # We've split all of the tests into separate files so they can be
+    # compiled in parallel which is significantly faster than having
+    # all of the tests in a single file.
+    testonly = True,
     srcs = [
         "bitwise_operator.cc",
         "callback.cc",
@@ -89,6 +92,17 @@ cc_test(
         ":http-mock-server",
         ":promisify-for-test",
         "//eventuals",
+    ],
+    # Setting it to False or leaving it absent will prevent base
+    # tests from running on Windows.
+    alwayslink = True,
+)
+
+cc_test(
+    name = "eventuals",
+    copts = copts(),
+    deps = [
+        ":base",
         "//test/concurrent",
         "@com_github_google_googletest//:gtest_main",
     ],


### PR DESCRIPTION
Currently, if we change anything in tests/concurrent - bazel will rebuild all of the base eventuals tests. This PR addresses this issue.