### PR TITLE
More python formatting to unblock dev-tools

### DIFF
--- a/protoc-gen-eventuals/protoc-gen-eventuals.py
+++ b/protoc-gen-eventuals/protoc-gen-eventuals.py
@@ -12,35 +12,25 @@ class EventualsProtocPlugin(ProtocPlugin):
     def analyze_file(self, proto_file: FileDescriptorProto) -> dict:
         return {
             'proto_file_name':
-                proto_file.name,
+            proto_file.name,
             'package_name':
-                proto_file.package,
-            'services':
-                [
-                    {
-                        'name':
-                            service.name,
-                        'methods':
-                            [
-                                {
-                                    'name':
-                                        method.name,
-                                    'input_type':
-                                        method.input_type,
-                                    'output_type':
-                                        method.output_type,
-                                    'client_streaming':
-                                        getattr(
-                                            method, 'client_streaming', False
-                                        ),
-                                    'server_streaming':
-                                        getattr(
-                                            method, 'server_streaming', False
-                                        ),
-                                } for method in service.method
-                            ],
-                    } for service in proto_file.service
-                ]
+            proto_file.package,
+            'services': [{
+                'name':
+                service.name,
+                'methods': [{
+                    'name':
+                    method.name,
+                    'input_type':
+                    method.input_type,
+                    'output_type':
+                    method.output_type,
+                    'client_streaming':
+                    getattr(method, 'client_streaming', False),
+                    'server_streaming':
+                    getattr(method, 'server_streaming', False),
+                } for method in service.method],
+            } for service in proto_file.service]
         }
 
     def process_file(self, proto_file: FileDescriptorProto):


### PR DESCRIPTION
It looks like the default codespace formatting settings (which I think
should use yapf) disagree with dev-tools as to how this should be
formatted: we should look into how to make the dev-tools style and the
VS Code autoformatter agree.
