### PR TITLE
Add 'expected' dependency for eventuals

### DIFF
--- a/bazel/deps.bzl
+++ b/bazel/deps.bzl
@@ -7,6 +7,7 @@ load("@com_github_3rdparty_bazel_rules_asio//bazel:deps.bzl", asio_deps = "deps"
 load("@com_github_3rdparty_bazel_rules_curl//bazel:deps.bzl", curl_deps = "deps")
 load("@com_github_3rdparty_bazel_rules_jemalloc//bazel:deps.bzl", jemalloc_deps = "deps")
 load("@com_github_3rdparty_bazel_rules_libuv//bazel:deps.bzl", libuv_deps = "deps")
+load("@com_github_3rdparty_bazel_rules_tl_expected//bazel:deps.bzl", expected_deps = "deps")
 load("@com_github_3rdparty_stout//bazel:deps.bzl", stout_deps = "deps")
 load("@com_github_grpc_grpc//bazel:grpc_deps.bzl", "grpc_deps")
 load("@com_github_reboot_dev_pyprotoc_plugin//bazel:deps.bzl", pyprotoc_plugin_deps = "deps")
@@ -25,6 +26,10 @@ def deps(repo_mapping = {}):
     bazel_skylib_workspace()
 
     curl_deps(
+        repo_mapping = repo_mapping,
+    )
+
+    expected_deps(
         repo_mapping = repo_mapping,
     )
 

--- a/bazel/repos.bzl
+++ b/bazel/repos.bzl
@@ -70,6 +70,15 @@ def repos(repo_mapping = {}):
     )
 
     maybe(
+        git_repository,
+        name = "com_github_3rdparty_bazel_rules_tl_expected",
+        remote = "https://github.com/3rdparty/bazel-rules-expected",
+        commit = "c703632657bf4ec9177d9aea0447166d424b3b74",
+        shallow_since = "1654243887 +0300",
+        repo_mapping = repo_mapping,
+    )
+
+    maybe(
         http_archive,
         name = "com_github_grpc_grpc",
         urls = ["https://github.com/grpc/grpc/archive/refs/tags/v1.45.0.tar.gz"],


### PR DESCRIPTION
Since we have [`bazelified`](https://github.com/3rdparty/bazel-rules-expected.git) `expected` [repo](https://github.com/TartanLlama/expected.git), now we can make eventuals also depend on this library too.
# DO NOT MERGE IT UNTIL THE PR IN `3rdparty/bazel-rules-expected` WILL BE MERGED!!!