### PR TITLE
Revert "Fix Dazel build"

### DIFF
--- a/Dockerfile.dazel
+++ b/Dockerfile.dazel
@@ -36,7 +36,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # https://docs.bazel.build/versions/main/install-ubuntu.html#install-on-ubuntu
 RUN echo "deb [arch=amd64] http://storage.googleapis.com/bazel-apt stable jdk1.8" > \
     /etc/apt/sources.list.d/bazel.list \
-    && curl -fsSL https://storage.googleapis.com/www.bazel.build/bazel-release.pub.gpg | apt-key add - \
+    && curl -fsSL https://bazel.build/bazel-release.pub.gpg | apt-key add - \
     && apt-get update && apt-get install -y bazel=${BAZEL_VERSION}
 
 # Install clang (and its dependencies).


### PR DESCRIPTION
Reverts 3rdparty/eventuals#413 since the signing key issue appears to be fixed.