### PR TITLE
Make `TypeCheck` work when mixing constness

### DIFF
--- a/eventuals/type-check.h
+++ b/eventuals/type-check.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <utility>
+
 #include "eventuals/eventual.h"
 
 ////////////////////////////////////////////////////////////////////////
@@ -19,8 +21,10 @@ struct _TypeCheck {
   template <typename Arg, typename K>
   auto k(K k) && {
     static_assert(
-        std::is_same_v<T_, ValueFrom<Arg>>,
-        "Failed to type check; expecting type on left, found type on right");
+        std::disjunction_v<
+            std::is_assignable<T_, ValueFrom<Arg>>,
+            std::is_convertible<ValueFrom<Arg>, T_>>,
+        "Failed to type check: Cannot return type on right into type on left");
 
     return std::move(e_).template k<Arg>(std::move(k));
   }

--- a/test/type-check.cc
+++ b/test/type-check.cc
@@ -1,34 +1,91 @@
 #include "eventuals/type-check.h"
 
+#include <memory>
 #include <vector>
 
 #include "eventuals/collect.h"
 #include "eventuals/iterate.h"
+#include "eventuals/just.h"
+#include "eventuals/then.h"
 #include "gtest/gtest.h"
 
 namespace eventuals::test {
 namespace {
 
 TEST(TypeCheck, Lvalue) {
-  std::vector<int> v = {5, 12};
-
-  auto s = [&]() {
-    return TypeCheck<int&>(Iterate(v))
-        | Collect<std::vector<int>>();
-  };
-
-  EXPECT_EQ(v, *s());
+  auto s = TypeCheck<int>(Just(4));
+  EXPECT_EQ(4, *s);
 }
-
 
 TEST(TypeCheck, Rvalue) {
-  auto s = []() {
-    return TypeCheck<int>(Iterate(std::vector<int>({5, 12})))
-        | Collect<std::vector<int>>();
-  };
+  auto s = TypeCheck<int>(Iterate(std::vector<int>({5, 12})))
+      | Collect<std::vector<int>>();
 
-  EXPECT_EQ(std::vector<int>({5, 12}), *s());
+  EXPECT_EQ(std::vector<int>({5, 12}), *s);
 }
+
+TEST(TypeCheck, Ref) {
+  int i = 4;
+  auto s = TypeCheck<int&>(Then([&]() -> int& { return i; }));
+  EXPECT_EQ(4, *s);
+}
+
+TEST(TypeCheck, ConstRef) {
+  int i = 4;
+  auto s = TypeCheck<const int&>(Then([&]() -> const int& { return i; }));
+  EXPECT_EQ(4, *s);
+}
+
+TEST(TypeCheck, ConstFromNonConstRef) {
+  int i = 4;
+  auto s = TypeCheck<const int&>(Then([&]() -> int& { return i; }));
+  EXPECT_EQ(4, *s);
+}
+
+TEST(TypeCheck, Pointer) {
+  int i = 4;
+  auto s = TypeCheck<int*>(Just(&i));
+  EXPECT_EQ(&i, *s);
+}
+
+TEST(TypeCheck, ConstPointer) {
+  int i = 4;
+  auto s = TypeCheck<const int*>(Just(&i));
+  EXPECT_EQ(&i, *s);
+}
+
+TEST(TypeCheck, ConstPointerFromNonConstPointer) {
+  int i = 4;
+  auto s = TypeCheck<const int*>(Then([&]() -> int* { return &i; }));
+  EXPECT_EQ(&i, *s);
+}
+
+TEST(TypeCheck, UniquePtr) {
+  auto s = [&]() {
+    return TypeCheck<std::unique_ptr<int>>(Just(std::make_unique<int>(4)));
+  };
+  EXPECT_EQ(4, **s());
+}
+
+TEST(TypeCheck, ConstUniquePtr) {
+  auto s = [&]() {
+    return TypeCheck<std::unique_ptr<const int>>(
+        Just(std::make_unique<const int>(4)));
+  };
+  EXPECT_EQ(4, **s());
+}
+
+TEST(TypeCheck, ConstUniquePtrFromNonConstUniquePtr) {
+  auto s = [&]() {
+    return TypeCheck<std::unique_ptr<const int>>(
+        Just(std::make_unique<int>(4)));
+  };
+  EXPECT_EQ(4, **s());
+}
+
+// TODO(xander): The whole point of TypeCheck is to *not* compile when types
+// don't match. Add non-compilation tests which only pass when invalid type
+// pairs correctly cause compilation errors.
 
 } // namespace
 } // namespace eventuals::test


### PR DESCRIPTION
Specifically, make this code pattern compile:
```c++
auto Method() {
    return ::eventuals::TypeCheck<std::unique_ptr<const MyType>>(
        ::eventuals::Then([]() {
            std::unique_ptr<MyType> ptr = std::make_unique<MyType>();
            // Return a non-const ptr that can be assigned to const ptr.
            return ptr;
        })
    );
}
```

Add a bunch of const-conversion tests.
