### PR TITLE
Revert "Make `TypeCheck` work when mixing constness"

### DIFF
--- a/eventuals/type-check.h
+++ b/eventuals/type-check.h
@@ -1,7 +1,5 @@
 #pragma once
 
-#include <utility>
-
 #include "eventuals/eventual.h"
 
 ////////////////////////////////////////////////////////////////////////
@@ -21,10 +19,8 @@ struct _TypeCheck {
   template <typename Arg, typename K>
   auto k(K k) && {
     static_assert(
-        std::disjunction_v<
-            std::is_assignable<T_, ValueFrom<Arg>>,
-            std::is_convertible<ValueFrom<Arg>, T_>>,
-        "Failed to type check: Cannot return type on right into type on left");
+        std::is_same_v<T_, ValueFrom<Arg>>,
+        "Failed to type check; expecting type on left, found type on right");
 
     return std::move(e_).template k<Arg>(std::move(k));
   }

--- a/test/type-check.cc
+++ b/test/type-check.cc
@@ -1,91 +1,34 @@
 #include "eventuals/type-check.h"
 
-#include <memory>
 #include <vector>
 
 #include "eventuals/collect.h"
 #include "eventuals/iterate.h"
-#include "eventuals/just.h"
-#include "eventuals/then.h"
 #include "gtest/gtest.h"
 
 namespace eventuals::test {
 namespace {
 
 TEST(TypeCheck, Lvalue) {
-  auto s = TypeCheck<int>(Just(4));
-  EXPECT_EQ(4, *s);
+  std::vector<int> v = {5, 12};
+
+  auto s = [&]() {
+    return TypeCheck<int&>(Iterate(v))
+        | Collect<std::vector<int>>();
+  };
+
+  EXPECT_EQ(v, *s());
 }
+
 
 TEST(TypeCheck, Rvalue) {
-  auto s = TypeCheck<int>(Iterate(std::vector<int>({5, 12})))
-      | Collect<std::vector<int>>();
-
-  EXPECT_EQ(std::vector<int>({5, 12}), *s);
-}
-
-TEST(TypeCheck, Ref) {
-  int i = 4;
-  auto s = TypeCheck<int&>(Then([&]() -> int& { return i; }));
-  EXPECT_EQ(4, *s);
-}
-
-TEST(TypeCheck, ConstRef) {
-  int i = 4;
-  auto s = TypeCheck<const int&>(Then([&]() -> const int& { return i; }));
-  EXPECT_EQ(4, *s);
-}
-
-TEST(TypeCheck, ConstFromNonConstRef) {
-  int i = 4;
-  auto s = TypeCheck<const int&>(Then([&]() -> int& { return i; }));
-  EXPECT_EQ(4, *s);
-}
-
-TEST(TypeCheck, Pointer) {
-  int i = 4;
-  auto s = TypeCheck<int*>(Just(&i));
-  EXPECT_EQ(&i, *s);
-}
-
-TEST(TypeCheck, ConstPointer) {
-  int i = 4;
-  auto s = TypeCheck<const int*>(Just(&i));
-  EXPECT_EQ(&i, *s);
-}
-
-TEST(TypeCheck, ConstPointerFromNonConstPointer) {
-  int i = 4;
-  auto s = TypeCheck<const int*>(Then([&]() -> int* { return &i; }));
-  EXPECT_EQ(&i, *s);
-}
-
-TEST(TypeCheck, UniquePtr) {
-  auto s = [&]() {
-    return TypeCheck<std::unique_ptr<int>>(Just(std::make_unique<int>(4)));
+  auto s = []() {
+    return TypeCheck<int>(Iterate(std::vector<int>({5, 12})))
+        | Collect<std::vector<int>>();
   };
-  EXPECT_EQ(4, **s());
-}
 
-TEST(TypeCheck, ConstUniquePtr) {
-  auto s = [&]() {
-    return TypeCheck<std::unique_ptr<const int>>(
-        Just(std::make_unique<const int>(4)));
-  };
-  EXPECT_EQ(4, **s());
+  EXPECT_EQ(std::vector<int>({5, 12}), *s());
 }
-
-TEST(TypeCheck, ConstUniquePtrFromNonConstUniquePtr) {
-  auto s = [&]() {
-    return TypeCheck<std::unique_ptr<const int>>(
-        Just(std::make_unique<int>(4)));
-  };
-  EXPECT_EQ(4, **s());
-}
-
-// TODO(xander): The whole point of TypeCheck is to *not* compile when types
-// don't match. Add non-compilation tests which only pass when invalid type
-// pairs correctly cause compilation errors.
 
 } // namespace
 } // namespace eventuals::test


### PR DESCRIPTION
Reverts 3rdparty/eventuals#441

#441 incorrectly made the following code compile:
```c++
TEST(TypeCheck, MutableVarConstReturnTypeMutableValue) {
  std::unique_ptr<int> result = *TypeCheck<std::unique_ptr<const int>>(
      Then([&]() -> std::unique_ptr<int> { return std::make_unique<int>(4); }));
  EXPECT_EQ(4, *result);
  *result = 5;
  EXPECT_EQ(5, *result);
}
```

This was because I incorrectly thought that `TypeCheck` was similar to declaring a return type, but it's not: the type specified in the `TypeCheck` doesn't affect the type seen by callers.

See discussion in https://github.com/reboot-dev/respect/pull/570/files/23d26d0b8dc0185b8e6e377b70d2e26fe5c995b5#diff-fa028406a1e7e59d2d16e6fac11b1cd2d15002a9001cd6ff7613fcc614e91926
