### PR TITLE
Use backwardcpp lib only on Mac and Linux while explicitly building test:eventuals

### DIFF
--- a/test/BUILD.bazel
+++ b/test/BUILD.bazel
@@ -97,7 +97,14 @@ cc_test(
         ":promisify-for-test",
         "//eventuals",
         "//test/concurrent",
-        "@com_github_backward_cpp//:backward",
         "@com_github_google_googletest//:gtest_main",
-    ],
+    ] + select({
+        # We support backward-cpp only for macOS and Linux.
+        # The support for Windows might be added in future.
+        # https://github.com/3rdparty/eventuals/issues/450
+        "@bazel_tools//src/conditions:windows": [],
+        "//conditions:default": [
+            "@com_github_backward_cpp//:backward",
+        ],
+    }),
 )


### PR DESCRIPTION
Currently, building `test:eventuals` target explicitly instead of building `...` on Windows results in bazel trying to build backwardcpp library, which we don't support on Windows at this moment.

I know that we wanted to go with `target_compatible_with` route, but it just makes it impossible to build some of our targets explicitly without usage of `...`.