### PR TITLE
Remove 'backward' cc_library target from test/eventuals

### DIFF
--- a/bazel/repos.bzl
+++ b/bazel/repos.bzl
@@ -1,6 +1,6 @@
 """Adds repositories/archives."""
 
-load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
+load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository", "new_git_repository")
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe")
 load("@com_github_3rdparty_stout//bazel:repos.bzl", stout_repos = "repos")
@@ -100,7 +100,16 @@ def repos(repo_mapping = {}):
         git_repository,
         name = "com_github_3rdparty_bazel_rules_backward_cpp",
         remote = "https://github.com/3rdparty/bazel-rules-backward-cpp",
-        commit = "4a63b4ddbd192d3cba994bc79a78540b3924bfbd",
-        shallow_since = "1657266408 +0300",
+        commit = "be06f4fce52e2327d877493d050f42b9d082af3f",
+        shallow_since = "1658132298 +0300",
         repo_mapping = repo_mapping,
+    )
+
+    maybe(
+        new_git_repository,
+        name = "com_github_3rdparty_bazel_rules_backward_cpp_stacktrace",
+        remote = "https://github.com/3rdparty/bazel-rules-backward-cpp",
+        build_file = "@com_github_3rdparty_bazel_rules_backward_cpp//:BUILD.backward-stacktrace.bazel",
+        commit = "be06f4fce52e2327d877493d050f42b9d082af3f",
+        shallow_since = "1658132298 +0300",
     )

--- a/test/BUILD.bazel
+++ b/test/BUILD.bazel
@@ -38,25 +38,6 @@ cc_library(
     ],
 )
 
-cc_library(
-    name = "backward",
-    srcs = ["backward-stacktrace.cc"],
-    hdrs = ["backward-stacktrace.h"],
-    copts = copts(),
-    # By default this target is visible from current package
-    # (test/BUILD.bazel). We need to make it visible for
-    # 'test/concurrent' and 'test/grpc' packages too.
-    visibility = [
-        "//test/concurrent:__pkg__",
-        "//test/grpc:__pkg__",
-    ],
-    deps = [
-        "@com_github_backward_cpp//:backward",
-        "@com_github_google_googletest//:gtest",
-    ],
-    alwayslink = True,
-)
-
 cc_test(
     name = "eventuals",
     srcs = [
@@ -114,7 +95,7 @@ cc_test(
         # https://github.com/3rdparty/eventuals/issues/450
         "@bazel_tools//src/conditions:windows": [],
         "//conditions:default": [
-            ":backward",
+            "@com_github_3rdparty_bazel_rules_backward_cpp_stacktrace//:backward-stacktrace",
         ],
     }),
 )

--- a/test/concurrent/BUILD.bazel
+++ b/test/concurrent/BUILD.bazel
@@ -46,7 +46,7 @@ cc_library(
         # https://github.com/3rdparty/eventuals/issues/450
         "@bazel_tools//src/conditions:windows": [],
         "//conditions:default": [
-            "//test:backward",
+            "@com_github_3rdparty_bazel_rules_backward_cpp_stacktrace//:backward-stacktrace",
         ],
     }),
     # Setting it to False or leaving it absent will prevent concurrent

--- a/test/grpc/BUILD.bazel
+++ b/test/grpc/BUILD.bazel
@@ -22,7 +22,7 @@ cc_binary(
         # https://github.com/3rdparty/eventuals/issues/450
         "@bazel_tools//src/conditions:windows": [],
         "//conditions:default": [
-            "//test:backward",
+            "@com_github_3rdparty_bazel_rules_backward_cpp_stacktrace//:backward-stacktrace",
         ],
     }),
 )
@@ -43,7 +43,7 @@ cc_binary(
         # https://github.com/3rdparty/eventuals/issues/450
         "@bazel_tools//src/conditions:windows": [],
         "//conditions:default": [
-            "//test:backward",
+            "@com_github_3rdparty_bazel_rules_backward_cpp_stacktrace//:backward-stacktrace",
         ],
     }),
 )
@@ -91,9 +91,9 @@ cc_test(
     deps = [
         ":death-constants",
         "//eventuals/grpc",
-        "//test:backward",
         "//test:promisify-for-test",
         "@bazel_tools//tools/cpp/runfiles",
+        "@com_github_3rdparty_bazel_rules_backward_cpp_stacktrace//:backward-stacktrace",
         "@com_github_google_googletest//:gtest",
         "@com_github_grpc_grpc//examples/protos:helloworld_cc_grpc",
         "@com_github_grpc_grpc//examples/protos:keyvaluestore",


### PR DESCRIPTION
Since 'backward-stacktrace.cc|.h' are completely unrelated to eventuals,
so it makes sense to keep them separate. This PR removes this files. Moreover, [#2](https://github.com/3rdparty/bazel-rules-backward-cpp/pull/2) moves this files to `3rdparty/bazel-rules-backward-cpp` repo. Thus it would be easy to use
that in '3rdparty/eventuals' and 'reboot-dev/respect' repos.