### PR TITLE
clangd and clang-tidy initial support

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,17 @@
+# Provides better readability.
+UseColor: true
+
+# NOTE: The checks were taken from
+# https://github.com/3rdparty/eventuals/pull/210
+# TODO: Discuss if we want to add some extra checks.
+# Available checks can be found here:
+# https://clang.llvm.org/extra/clang-tidy/checks/list.html
+Checks: >
+    bugprone-*,
+    clang-analyzer-cplusplus*,
+    concurrency-*,
+    cppcoreguidelines-*,
+    google-*,
+    modernize-*,
+    performance-*,
+    readability-*,

--- a/.clangd
+++ b/.clangd
@@ -1,0 +1,7 @@
+# If there are too many errors, clangd, by default, does not show them, but instead
+# emits the error [clang: fatal_too_many_errors].
+# It's not helpful at all, so the following option disables this behaviour 
+# and forces clangd to continue running.
+# https://github.com/clangd/coc-clangd/issues/255
+CompileFlags:
+  Add: -ferror-limit=0

--- a/.gitignore
+++ b/.gitignore
@@ -2,9 +2,17 @@
 .vscode
 .DS_Store
 user.bazelrc
-.dazel_run
-bazel-*
 *~
 
 # Runtime file for Dazel.
 .dazel_run
+
+### Added by Hedron's Bazel Compile Commands Extractor: https://github.com/hedronvision/bazel-compile-commands-extractor
+# The external link: Differs on Windows vs macOS/Linux, so we can't check it in. The pattern needs to not have a trailing / because it's a symlink on macOS/Linux.
+/external
+# Bazel output symlinks: Same reasoning as /external. You need the * because people can change the name of the directory your repository is cloned into, changing the bazel-<workspace_name> symlink.
+/bazel-*
+# Compiled output -> don't check in
+/compile_commands.json
+# Directory where clangd puts its indexing work
+/.cache/

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,3 +1,7 @@
+load("@hedron_compile_commands//:refresh_compile_commands.bzl", "refresh_compile_commands")
+
+########################################################################
+
 # TODO(alexmc): Remove this alias.
 alias(
     name = "eventuals",
@@ -13,3 +17,45 @@ alias(
     deprecation = "Prefer //eventuals/grpc",
     visibility = ["//visibility:public"],
 )
+
+########################################################################
+
+# Hedron's Compile Commands Extractor for Bazel.
+# Follow the link to learn how to set it up for your code editor:
+# https://github.com/hedronvision/bazel-compile-commands-extractor
+# NOTE: This rule is crucial for clangd and clang-tidy to work.
+# Its output is used by clangd and clang-tidy to understand the build process.
+# TODO(folming): find a cleaner way to make it automatic depending on the platform.
+# select() doesn't work, produces the error: "unhashable type: 'select'".
+# TODO(folming): move the rules to a separate bazel file.
+
+refresh_compile_commands(
+    name = "refresh_cc_windows",
+    # Add additional targets in here if needed.
+    # The value for keys is meant for additional bazel build arguments, e.g.
+    # "//test:eventuals": "--compilation_mode=dbg".
+    targets = {
+        "//test:eventuals": "",
+    },
+)
+
+refresh_compile_commands(
+    name = "refresh_cc_default",
+    # Add additional targets in here if needed.
+    # The value for keys is meant for additional bazel build arguments, e.g.
+    # "//test:eventuals": "--compilation_mode=dbg".
+    targets = {
+        "//test/grpc:grpc": "",
+        "//test:eventuals": "",
+    },
+)
+
+alias(
+    name = "refresh_cc",  # refresh_compile_commands
+    actual = select({
+        "@bazel_tools//src/conditions:windows": "refresh_cc_windows",
+        "//conditions:default": "refresh_cc_default",
+    }),
+)
+
+########################################################################

--- a/WORKSPACE.bazel
+++ b/WORKSPACE.bazel
@@ -19,3 +19,23 @@ load("@com_github_grpc_grpc//bazel:grpc_extra_deps.bzl", "grpc_extra_deps")
 grpc_extra_deps()
 
 ########################################################################
+
+load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
+
+# Hedron's Compile Commands Extractor for Bazel.
+# Latest version available on 2022/07/18.
+# Follow the link to learn how to set it up for your code editor:
+# https://github.com/hedronvision/bazel-compile-commands-extractor
+# TODO(folming): move the rules to a separate bazel file.
+git_repository(
+    name = "hedron_compile_commands",
+    commit = "05610f52a2ea3cda6ac27133b96f71c36358adf9",
+    remote = "https://github.com/hedronvision/bazel-compile-commands-extractor",
+    shallow_since = "1657677319 -0700",
+)
+
+load("@hedron_compile_commands//:workspace_setup.bzl", "hedron_compile_commands_setup")
+
+hedron_compile_commands_setup()
+
+########################################################################


### PR DESCRIPTION
Allows [clangd](https://clangd.llvm.org/) LSP to work in VS Code (or any other IDE/Code Editor that has some kind of a support for clangd).

The output of the added rule can also be used in [clang-tidy](https://clang.llvm.org/extra/clang-tidy/) (which is how https://github.com/3rdparty/eventuals/pull/465 PR was created).

The README in https://github.com/hedronvision/bazel-compile-commands-extractor was especially helpful in the process of setting everything up.
