### PR TITLE
Prefer to use `malloc` to override malloc

### DIFF
--- a/bazel/malloc.bzl
+++ b/bazel/malloc.bzl
@@ -1,0 +1,11 @@
+"""Defines malloc implementations for the specific OS."""
+
+def malloc():
+    """Returns malloc implementations for the specific OS."""
+    return select({
+        # TODO(https://github.com/3rdparty/eventuals/issues/124):
+        # Build jemalloc on Windows
+        # https://github.com/3rdparty/bazel-rules-jemalloc/tree/ArthurBandaryk.jemalloc-windows
+        "@bazel_tools//src/conditions:windows": "@bazel_tools//tools/cpp:malloc",
+        "//conditions:default": "@com_github_jemalloc_jemalloc//:jemalloc",
+    })

--- a/eventuals/BUILD.bazel
+++ b/eventuals/BUILD.bazel
@@ -65,18 +65,7 @@ cc_library(
         "@com_github_3rdparty_stout//:stout",
         "@com_github_google_glog//:glog",
         "@com_github_tl_expected//:expected",
-    ] + select({
-        # NOTE!
-        # For now we build jemalloc on macOS and Linux.
-        # The way how to build jemalloc on Windows is more
-        # complicated. In future we are going to make this
-        # lib build on Windows too.
-        # https://github.com/3rdparty/bazel-rules-jemalloc/tree/ArthurBandaryk.jemalloc-windows
-        "@bazel_tools//src/conditions:windows": [],
-        "//conditions:default": [
-            "@com_github_jemalloc_jemalloc//:jemalloc",
-        ],
-    }),
+    ],
 )
 
 cc_library(

--- a/test/BUILD.bazel
+++ b/test/BUILD.bazel
@@ -1,5 +1,6 @@
 load("@rules_cc//cc:defs.bzl", "cc_library", "cc_test")
 load("//bazel:copts.bzl", "copts")
+load("//bazel:malloc.bzl", "malloc")
 
 cc_library(
     name = "generate-test-task-name",
@@ -82,6 +83,8 @@ cc_test(
         "unpack.cc",
     ],
     copts = copts(),
+    # Use a faster implementation of malloc (and show that tests pass with it).
+    malloc = malloc(),
     deps = [
         ":generate-test-task-name",
         ":http-mock-server",

--- a/test/grpc/BUILD.bazel
+++ b/test/grpc/BUILD.bazel
@@ -1,5 +1,6 @@
 load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library", "cc_test")
 load("//bazel:copts.bzl", "copts")
+load("//bazel:malloc.bzl", "malloc")
 
 cc_library(
     name = "death-constants",
@@ -12,6 +13,8 @@ cc_binary(
         "death-client.cc",
     ],
     copts = copts(),
+    # Use a faster implementation of malloc (and show that tests pass with it).
+    malloc = malloc(),
     deps = [
         ":death-constants",
         "//eventuals/grpc",
@@ -33,6 +36,8 @@ cc_binary(
         "death-server.cc",
     ],
     copts = copts(),
+    # Use a faster implementation of malloc (and show that tests pass with it).
+    malloc = malloc(),
     deps = [
         ":death-constants",
         "//eventuals/grpc",
@@ -77,6 +82,8 @@ cc_test(
         ":death-client",
         ":death-server",
     ],
+    # Use a faster implementation of malloc (and show that tests pass with it).
+    malloc = malloc(),
     # This test is fairly fast, but our GitHub Action Runner compiles with
     # -c dbg --config=asan (~1s per test) and runs it 100x which often hits
     # the default "short" timeout without sharding.


### PR DESCRIPTION
This is recommended here: https://github.com/bazelbuild/bazel/issues/818#issuecomment-180362316

But more importantly, this fixes issues when trying to include eventuals
in targets that are built as shared libraries.

Fixes https://github.com/3rdparty/eventuals/issues/470.