### PR TITLE
Add an option for users to overload an eventuals::Collector for Collect()

### DIFF
--- a/eventuals/BUILD.bazel
+++ b/eventuals/BUILD.bazel
@@ -65,7 +65,6 @@ cc_library(
         "@com_github_3rdparty_stout//:stout",
         "@com_github_google_glog//:glog",
         "@com_github_tl_expected//:expected",
-        "@com_google_protobuf//:protobuf",
     ],
 )
 

--- a/eventuals/protobuf/BUILD.bazel
+++ b/eventuals/protobuf/BUILD.bazel
@@ -1,0 +1,15 @@
+load("@rules_cc//cc:defs.bzl", "cc_library")
+load("//bazel:copts.bzl", "copts")
+
+cc_library(
+    name = "protobuf",
+    hdrs = [
+        "collectors.h",
+    ],
+    copts = copts(),
+    visibility = ["//visibility:public"],
+    deps = [
+        "//eventuals",
+        "@com_google_protobuf//:protobuf",
+    ],
+)

--- a/eventuals/protobuf/collectors.h
+++ b/eventuals/protobuf/collectors.h
@@ -1,0 +1,54 @@
+#pragma once
+
+#include "eventuals/collect.h"
+#include "google/protobuf/repeated_field.h"
+
+////////////////////////////////////////////////////////////////////////
+
+namespace eventuals {
+
+////////////////////////////////////////////////////////////////////////
+
+template <typename Collection>
+struct Collector<
+    Collection,
+    std::enable_if_t<
+        std::is_same_v<
+            Collection,
+            google::protobuf::RepeatedPtrField<
+                typename Collection::value_type>>>> {
+  template <typename T>
+  static void Collect(Collection& collection, T&& value) {
+    static_assert(std::is_convertible_v<T, typename Collection::value_type>);
+    if constexpr (std::is_lvalue_reference_v<T&&>) {
+      collection.Add(std::decay_t<T>(value));
+    } else if constexpr (std::is_rvalue_reference_v<T&&>) {
+      collection.Add(std::move(value));
+    } else {
+      static_assert(always_false_v<T>, "Unreachable");
+    }
+  }
+};
+
+template <typename Collection>
+struct Collector<
+    Collection,
+    std::enable_if_t<
+        std::is_same_v<
+            Collection,
+            google::protobuf::RepeatedField<
+                typename Collection::value_type>>>> {
+  template <typename T>
+  static void Collect(Collection& collection, T&& value) {
+    static_assert(std::is_convertible_v<T, typename Collection::value_type>);
+    static_assert(std::is_pod_v<std::decay_t<T>>);
+    // Add expects an lvalue reference, so we don't use std::forward here.
+    collection.Add(value);
+  }
+};
+
+////////////////////////////////////////////////////////////////////////
+
+} // namespace eventuals
+
+////////////////////////////////////////////////////////////////////////

--- a/eventuals/type-traits.h
+++ b/eventuals/type-traits.h
@@ -25,6 +25,11 @@ struct void_template {
 
 ////////////////////////////////////////////////////////////////////////
 
+template <typename>
+inline constexpr bool always_false_v = false;
+
+////////////////////////////////////////////////////////////////////////
+
 // TODO(benh): Replace with std::type_identity from C++20.
 template <typename T>
 struct type_identity {
@@ -58,6 +63,20 @@ template <typename T>
 struct HasEmplaceBack<
     T,
     std::void_t<decltype(std::declval<T>().emplace_back(
+        std::declval<typename T::value_type&&>()))>>
+  : std::true_type {
+};
+
+////////////////////////////////////////////////////////////////////////
+
+template <typename, typename = void>
+struct HasInsert : std::false_type {
+};
+
+template <typename T>
+struct HasInsert<
+    T,
+    std::void_t<decltype(std::declval<T>().insert(
         std::declval<typename T::value_type&&>()))>>
   : std::true_type {
 };

--- a/test/collect.cc
+++ b/test/collect.cc
@@ -1,16 +1,20 @@
 #include "eventuals/collect.h"
 
 #include <set>
+#include <utility>
 #include <vector>
 
 #include "eventuals/iterate.h"
 #include "eventuals/promisify.h"
+#include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
 namespace eventuals::test {
 namespace {
 
-TEST(Collect, CommonVectorPass) {
+using testing::ElementsAre;
+
+TEST(Collect, VectorPass) {
   std::vector<int> v = {5, 12};
 
   auto s = [&]() {
@@ -20,12 +24,16 @@ TEST(Collect, CommonVectorPass) {
 
   std::vector<int> result = *s();
 
-  ASSERT_EQ(2, result.size());
-  EXPECT_EQ(5, result.at(0));
-  EXPECT_EQ(12, result.at(1));
+  ASSERT_EQ(result.size(), 2);
+  EXPECT_THAT(result, ElementsAre(5, 12));
+
+  // The initial vector should remain unchanged.
+  ASSERT_EQ(v.size(), 2);
+  EXPECT_THAT(v, ElementsAre(5, 12));
 }
 
-TEST(Collect, CommonSetPass) {
+
+TEST(Collect, SetPass) {
   std::set<int> v = {5, 12};
 
   auto s = [&]() {
@@ -35,39 +43,12 @@ TEST(Collect, CommonSetPass) {
 
   std::set<int> result = *s();
 
-  ASSERT_EQ(2, result.size());
-  EXPECT_EQ(5, *result.begin());
-  EXPECT_EQ(12, *++result.begin());
-}
+  ASSERT_EQ(result.size(), 2);
+  EXPECT_THAT(result, ElementsAre(5, 12));
 
-TEST(Collect, VectorToRepeatedPtrField) {
-  std::vector<std::string> v = {"Hello", "World"};
-
-  auto s = [&]() {
-    return Iterate(v)
-        | Collect<google::protobuf::RepeatedPtrField<std::string>>();
-  };
-
-  google::protobuf::RepeatedPtrField<std::string> result = *s();
-
-  ASSERT_EQ(2, result.size());
-  EXPECT_EQ("Hello", *result.begin());
-  EXPECT_EQ("World", *(result.begin() + 1));
-}
-
-TEST(Collect, VectorToRepeatedField) {
-  std::vector<int> v = {42, 25};
-
-  auto s = [&]() {
-    return Iterate(v)
-        | Collect<google::protobuf::RepeatedField<int>>();
-  };
-
-  google::protobuf::RepeatedField<int> result = *s();
-
-  ASSERT_EQ(2, result.size());
-  EXPECT_EQ(42, *result.begin());
-  EXPECT_EQ(25, *(result.begin() + 1));
+  // The initial set should remain unchanged.
+  ASSERT_EQ(v.size(), 2);
+  EXPECT_THAT(v, ElementsAre(5, 12));
 }
 
 } // namespace

--- a/test/filter.cc
+++ b/test/filter.cc
@@ -42,6 +42,7 @@ TEST(Filter, OddLoopFlow) {
   EXPECT_EQ(22, *s());
 }
 
+
 TEST(Filter, OddCollectFlow) {
   std::vector<int> v = {5, 12, 17};
   auto begin = v.begin();
@@ -55,6 +56,7 @@ TEST(Filter, OddCollectFlow) {
 
   EXPECT_THAT(*s(), ElementsAre(5, 17));
 }
+
 
 TEST(Filter, OddMapLoopFlow) {
   std::vector<int> v = {5, 12, 17};
@@ -76,6 +78,7 @@ TEST(Filter, OddMapLoopFlow) {
 
   EXPECT_EQ(24, *s());
 }
+
 
 TEST(Filter, OddMapCollectFlow) {
   std::vector<int> v = {5, 12, 17};

--- a/test/flat-map.cc
+++ b/test/flat-map.cc
@@ -198,8 +198,8 @@ TEST_F(FlatMapTest, Interrupt) {
            })
         | FlatMap([](int x) { return Iterate({1, 2}); })
         | Collect<std::vector<int>>()
-              .stop([](auto& data, auto& k) {
-                k.Start(std::move(data));
+              .stop([](auto& collection, auto& k) {
+                k.Start(std::move(collection));
               });
   };
 

--- a/test/protobuf/BUILD.bazel
+++ b/test/protobuf/BUILD.bazel
@@ -1,0 +1,25 @@
+load("@rules_cc//cc:defs.bzl", "cc_test")
+load("//bazel:copts.bzl", "copts")
+load("//bazel:malloc.bzl", "malloc")
+
+cc_test(
+    name = "protobuf",
+    srcs = [
+        "collect.cc",
+    ],
+    copts = copts(),
+    malloc = malloc(),
+    deps = [
+        "//eventuals/protobuf",
+        "@com_github_google_googletest//:gtest_main",
+        "@com_google_protobuf//:protobuf",
+    ] + select({
+        # We support backward lib only for macOS and Linux.
+        # The support for Windows might be added in future.
+        # https://github.com/3rdparty/eventuals/issues/450
+        "@bazel_tools//src/conditions:windows": [],
+        "//conditions:default": [
+            "@com_github_3rdparty_bazel_rules_backward_cpp_stacktrace//:backward-stacktrace",
+        ],
+    }),
+)

--- a/test/protobuf/collect.cc
+++ b/test/protobuf/collect.cc
@@ -1,0 +1,76 @@
+#include "eventuals/iterate.h"
+#include "eventuals/promisify.h"
+#include "eventuals/protobuf/collectors.h"
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+
+namespace eventuals::test {
+namespace {
+
+using testing::ElementsAre;
+
+TEST(Collect, VectorToRepeatedPtrField) {
+  std::vector<std::string> v = {"Hello", "World"};
+
+  auto s = [&]() {
+    return Iterate(v)
+        | Collect<google::protobuf::RepeatedPtrField<std::string>>();
+  };
+
+  google::protobuf::RepeatedPtrField<std::string> result = *s();
+
+  ASSERT_EQ(result.size(), 2);
+  EXPECT_THAT(result, ElementsAre("Hello", "World"));
+
+  // The initial vector should remain unchanged.
+  ASSERT_EQ(v.size(), 2);
+  EXPECT_THAT(v, ElementsAre("Hello", "World"));
+}
+
+
+TEST(Collect, MoveValueIntoRepeatedPtrField) {
+  std::string initial_str = "Hello";
+
+  auto s = [&]() {
+    return Stream<std::string>()
+               .context(false)
+               .next([&](auto& was_completed, auto& k) {
+                 if (!was_completed) {
+                   was_completed = true;
+                   k.Emit(std::move(initial_str));
+                 } else {
+                   k.Ended();
+                 }
+               })
+        | Collect<google::protobuf::RepeatedPtrField<std::string>>();
+  };
+
+  google::protobuf::RepeatedPtrField<std::string> result = *s();
+
+  ASSERT_EQ(result.size(), 1);
+  EXPECT_THAT(result, ElementsAre("Hello"));
+
+  EXPECT_EQ(initial_str, "");
+}
+
+
+TEST(Collect, VectorToRepeatedField) {
+  std::vector<int> v = {42, 25};
+
+  auto s = [&]() {
+    return Iterate(v)
+        | Collect<google::protobuf::RepeatedField<int>>();
+  };
+
+  google::protobuf::RepeatedField<int> result = *s();
+
+  ASSERT_EQ(result.size(), 2);
+  EXPECT_THAT(result, ElementsAre(42, 25));
+
+  // The initial vector should remain unchanged.
+  ASSERT_EQ(v.size(), 2);
+  EXPECT_THAT(v, ElementsAre(42, 25));
+}
+
+} // namespace
+} // namespace eventuals::test


### PR DESCRIPTION
Makes `Collect()` more generic and allows others to extend its functionality to other collections by implementing their own `eventuals::Collector`.