### PR TITLE
Erase Collect's collection type

### DIFF
--- a/test/collect.cc
+++ b/test/collect.cc
@@ -19,7 +19,7 @@ TEST(Collect, VectorPass) {
 
   auto s = [&]() {
     return Iterate(v)
-        | Collect<std::vector<int>>();
+        | Collect<std::vector>();
   };
 
   std::vector<int> result = *s();
@@ -38,7 +38,7 @@ TEST(Collect, SetPass) {
 
   auto s = [&]() {
     return Iterate(v)
-        | Collect<std::set<int>>();
+        | Collect<std::set>();
   };
 
   std::set<int> result = *s();
@@ -47,6 +47,25 @@ TEST(Collect, SetPass) {
   EXPECT_THAT(result, ElementsAre(5, 12));
 
   // The initial set should remain unchanged.
+  ASSERT_EQ(v.size(), 2);
+  EXPECT_THAT(v, ElementsAre(5, 12));
+}
+
+
+TEST(Collect, TypedCollection) {
+  std::vector<int> v = {5, 12};
+
+  auto s = [&]() {
+    return Iterate(v)
+        | Collect<std::vector<long long>>();
+  };
+
+  std::vector<long long> result = *s();
+
+  ASSERT_EQ(result.size(), 2);
+  EXPECT_THAT(result, ElementsAre(5, 12));
+
+  // The initial vector should remain unchanged.
   ASSERT_EQ(v.size(), 2);
   EXPECT_THAT(v, ElementsAre(5, 12));
 }

--- a/test/concurrent/emit-fail-interrupt.cc
+++ b/test/concurrent/emit-fail-interrupt.cc
@@ -53,7 +53,7 @@ TYPED_TEST(ConcurrentTypedTest, EmitFailInterrupt) {
                   });
             }));
           })
-        | Collect<std::vector<std::string>>();
+        | Collect<std::vector>();
   };
 
   static_assert(

--- a/test/concurrent/emit-interrupt-fail.cc
+++ b/test/concurrent/emit-interrupt-fail.cc
@@ -39,7 +39,7 @@ TYPED_TEST(ConcurrentTypedTest, EmitInterruptFail) {
               return std::to_string(i);
             });
           })
-        | Collect<std::vector<std::string>>();
+        | Collect<std::vector>();
   };
 
   static_assert(

--- a/test/concurrent/emit-interrupt-stop.cc
+++ b/test/concurrent/emit-interrupt-stop.cc
@@ -35,7 +35,7 @@ TYPED_TEST(ConcurrentTypedTest, EmitInterruptStop) {
               return std::to_string(i);
             });
           })
-        | Collect<std::vector<std::string>>();
+        | Collect<std::vector>();
   };
 
   static_assert(

--- a/test/concurrent/emit-stop-interrupt.cc
+++ b/test/concurrent/emit-stop-interrupt.cc
@@ -41,7 +41,7 @@ TYPED_TEST(ConcurrentTypedTest, EmitStopInterrupt) {
               });
             }));
           })
-        | Collect<std::vector<std::string>>();
+        | Collect<std::vector>();
   };
 
   static_assert(

--- a/test/concurrent/fail-before-start.cc
+++ b/test/concurrent/fail-before-start.cc
@@ -49,7 +49,7 @@ TYPED_TEST(ConcurrentTypedTest, FailBeforeStart) {
                   });
             }));
           })
-        | Collect<std::vector<std::string>>();
+        | Collect<std::vector>();
   };
 
   static_assert(

--- a/test/concurrent/fail-or-stop.cc
+++ b/test/concurrent/fail-or-stop.cc
@@ -43,7 +43,7 @@ TYPED_TEST(ConcurrentTypedTest, FailOrStop) {
                   });
             }));
           })
-        | Collect<std::vector<std::string>>();
+        | Collect<std::vector>();
   };
 
   static_assert(

--- a/test/concurrent/fail.cc
+++ b/test/concurrent/fail.cc
@@ -47,7 +47,7 @@ TYPED_TEST(ConcurrentTypedTest, Fail) {
                   });
             }));
           })
-        | Collect<std::vector<std::string>>();
+        | Collect<std::vector>();
   };
 
   static_assert(

--- a/test/concurrent/flat-map.cc
+++ b/test/concurrent/flat-map.cc
@@ -24,7 +24,7 @@ TYPED_TEST(ConcurrentTypedTest, FlatMap) {
               return Range(i);
             });
           })
-        | Collect<std::vector<int>>();
+        | Collect<std::vector>();
   };
 
   static_assert(

--- a/test/concurrent/interrupt-fail-or-stop.cc
+++ b/test/concurrent/interrupt-fail-or-stop.cc
@@ -48,7 +48,7 @@ TYPED_TEST(ConcurrentTypedTest, InterruptFailOrStop) {
                   });
             }));
           })
-        | Collect<std::vector<std::string>>();
+        | Collect<std::vector>();
   };
 
   static_assert(

--- a/test/concurrent/interrupt-fail.cc
+++ b/test/concurrent/interrupt-fail.cc
@@ -41,7 +41,7 @@ TYPED_TEST(ConcurrentTypedTest, InterruptFail) {
                   });
             }));
           })
-        | Collect<std::vector<std::string>>();
+        | Collect<std::vector>();
   };
 
   static_assert(

--- a/test/concurrent/interrupt-stop.cc
+++ b/test/concurrent/interrupt-stop.cc
@@ -36,7 +36,7 @@ TYPED_TEST(ConcurrentTypedTest, InterruptStop) {
                   });
             }));
           })
-        | Collect<std::vector<std::string>>();
+        | Collect<std::vector>();
   };
 
   static_assert(

--- a/test/concurrent/interrupt-success.cc
+++ b/test/concurrent/interrupt-success.cc
@@ -40,7 +40,7 @@ TYPED_TEST(ConcurrentTypedTest, InterruptSuccess) {
                   });
             }));
           })
-        | Collect<std::vector<std::string>>();
+        | Collect<std::vector>();
   };
 
   static_assert(

--- a/test/concurrent/moveable.cc
+++ b/test/concurrent/moveable.cc
@@ -26,7 +26,7 @@ TYPED_TEST(ConcurrentTypedTest, Moveable) {
               return 42;
             }));
           })
-        | Collect<std::vector<int>>();
+        | Collect<std::vector>();
   };
 
   static_assert(

--- a/test/concurrent/stop-before-start.cc
+++ b/test/concurrent/stop-before-start.cc
@@ -43,7 +43,7 @@ TYPED_TEST(ConcurrentTypedTest, StopBeforeStart) {
                   });
             }));
           })
-        | Collect<std::vector<std::string>>();
+        | Collect<std::vector>();
   };
 
   static_assert(

--- a/test/concurrent/stop.cc
+++ b/test/concurrent/stop.cc
@@ -41,7 +41,7 @@ TYPED_TEST(ConcurrentTypedTest, Stop) {
                   });
             }));
           })
-        | Collect<std::vector<std::string>>();
+        | Collect<std::vector>();
   };
 
   static_assert(

--- a/test/concurrent/stream-fail.cc
+++ b/test/concurrent/stream-fail.cc
@@ -27,7 +27,7 @@ TYPED_TEST(ConcurrentTypedTest, StreamFail) {
               return std::to_string(i);
             });
           })
-        | Collect<std::vector<std::string>>();
+        | Collect<std::vector>();
   };
 
   static_assert(

--- a/test/concurrent/stream-stop.cc
+++ b/test/concurrent/stream-stop.cc
@@ -22,7 +22,7 @@ TYPED_TEST(ConcurrentTypedTest, StreamStop) {
               return std::to_string(i);
             });
           })
-        | Collect<std::vector<std::string>>();
+        | Collect<std::vector>();
   };
 
   static_assert(

--- a/test/concurrent/success.cc
+++ b/test/concurrent/success.cc
@@ -37,7 +37,7 @@ TYPED_TEST(ConcurrentTypedTest, Success) {
                   });
             }));
           })
-        | Collect<std::vector<std::string>>();
+        | Collect<std::vector>();
   };
 
   static_assert(

--- a/test/filter.cc
+++ b/test/filter.cc
@@ -51,7 +51,7 @@ TEST(Filter, OddCollectFlow) {
   auto s = [&]() {
     return Iterate(begin, end)
         | Filter([](int x) { return x % 2 == 1; })
-        | Collect<std::set<int>>();
+        | Collect<std::set>();
   };
 
   EXPECT_THAT(*s(), ElementsAre(5, 17));
@@ -87,7 +87,7 @@ TEST(Filter, OddMapCollectFlow) {
     return Iterate(v)
         | Filter([](int x) { return x % 2 == 1; })
         | Map([](int x) { return x + 1; })
-        | Collect<std::unordered_set<int>>();
+        | Collect<std::unordered_set>();
   };
 
   EXPECT_THAT(*s(), UnorderedElementsAre(6, 18));

--- a/test/flat-map.cc
+++ b/test/flat-map.cc
@@ -30,7 +30,7 @@ TEST(FlatMap, TwoLevelLoop) {
   auto s = []() {
     return Range(2)
         | FlatMap([](int x) { return Range(2); })
-        | Collect<std::vector<int>>();
+        | Collect<std::vector>();
   };
 
   EXPECT_THAT(*s(), ElementsAre(0, 1, 0, 1));
@@ -41,7 +41,7 @@ TEST(FlatMap, FlatMapMapped) {
     return Range(2)
         | FlatMap([](int x) { return Range(2); })
         | Map([](int x) { return x + 1; })
-        | Collect<std::vector<int>>();
+        | Collect<std::vector>();
   };
 
   EXPECT_THAT(*s(), ElementsAre(1, 2, 1, 2));
@@ -55,7 +55,7 @@ TEST(FlatMap, FlatMapIterate) {
              return Iterate(std::move(v));
            })
         | Map([](int x) { return x + 1; })
-        | Collect<std::vector<int>>();
+        | Collect<std::vector>();
   };
 
   EXPECT_THAT(*s(), ElementsAre(2, 3, 4, 2, 3, 4));
@@ -79,7 +79,7 @@ TEST(FlatMap, TwoIndexesSum) {
                    k.Ended();
                  });
            })
-        | Collect<std::vector<int>>();
+        | Collect<std::vector>();
   };
 
   EXPECT_THAT(*s(), ElementsAre(1, 2, 2, 3, 3, 4));
@@ -92,7 +92,7 @@ TEST(FlatMap, TwoIndexesSumMap) {
              return Range(1, 3)
                  | Map([x](int y) { return x + y; });
            })
-        | Collect<std::vector<int>>();
+        | Collect<std::vector>();
   };
 
   EXPECT_THAT(*s(), ElementsAre(1, 2, 2, 3, 3, 4));
@@ -107,7 +107,7 @@ TEST(FlatMap, Let) {
                       return Iterate({x, y});
                     }));
            }))
-        | Collect<std::vector<int>>();
+        | Collect<std::vector>();
   };
 
   EXPECT_THAT(*s(), ElementsAre(1, 1, 1, 2, 2, 1, 2, 2));
@@ -121,7 +121,7 @@ TEST(FlatMap, FlatMapIterateString) {
              return Iterate(std::move(v));
            })
         | Map([](int x) { return x + 1; })
-        | Collect<std::vector<int>>();
+        | Collect<std::vector>();
   };
 
   EXPECT_THAT(*s(), ElementsAre(2, 3, 4, 2, 3, 4));
@@ -132,7 +132,7 @@ TEST(FlatMap, ThreeLevelLoop) {
     return Range(2)
         | FlatMap([](int x) { return Range(2); })
         | FlatMap([](int x) { return Range(2); })
-        | Collect<std::vector<int>>();
+        | Collect<std::vector>();
   };
 
   EXPECT_THAT(*s(), ElementsAre(0, 1, 0, 1, 0, 1, 0, 1));
@@ -147,7 +147,7 @@ TEST(FlatMap, ThreeLevelLoopInside) {
                       return Range(2);
                     });
            })
-        | Collect<std::vector<int>>();
+        | Collect<std::vector>();
   };
 
   EXPECT_THAT(*s(), ElementsAre(0, 1, 0, 1, 0, 1, 0, 1));
@@ -164,7 +164,7 @@ TEST(FlatMap, ThreeIndexesSumMap) {
              return Range(1, 3)
                  | Map([sum](int z) { return sum + z; });
            })
-        | Collect<std::vector<int>>();
+        | Collect<std::vector>();
   };
 
   EXPECT_THAT(*s(), ElementsAre(2, 3, 3, 4, 3, 4, 4, 5, 4, 5, 5, 6));
@@ -181,7 +181,7 @@ TEST(FlatMap, VectorVector) {
              return Iterate(std::move(c));
            })
         | FlatMap([](std::vector<int> x) { return Range(2); })
-        | Collect<std::vector<int>>();
+        | Collect<std::vector>();
   };
 
   EXPECT_THAT(*s(), ElementsAre(0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1));
@@ -239,7 +239,7 @@ TEST(FlatMap, InterruptReturn) {
                    k.Ended();
                  });
            })
-        | Collect<std::vector<int>>();
+        | Collect<std::vector>();
   };
 
   auto [future, k] = PromisifyForTest(e());

--- a/test/generator.cc
+++ b/test/generator.cc
@@ -39,7 +39,7 @@ TEST(Generator, Succeed) {
 
   auto e1 = [&]() {
     return stream()
-        | Collect<std::vector<int>>();
+        | Collect<std::vector>();
   };
 
   EXPECT_THAT(*e1(), ElementsAre(1, 2, 3));
@@ -62,7 +62,7 @@ TEST(Generator, Succeed) {
         | Map([](auto x) {
              return x + 1;
            })
-        | Collect<std::vector<int>>();
+        | Collect<std::vector>();
   };
 
   EXPECT_THAT(*e3(), ElementsAre(2, 3, 4));
@@ -77,7 +77,7 @@ TEST(Generator, Succeed) {
 
   auto e4 = [&stream2]() {
     return stream2()
-        | Collect<std::vector<int>>();
+        | Collect<std::vector>();
   };
 
   EXPECT_THAT(*e4(), ElementsAre(1, 2, 3));
@@ -392,7 +392,7 @@ TEST(Generator, TaskWithGenerator) {
   auto task = [&]() -> Task::Of<std::vector<int>> {
     return [&]() {
       return stream()
-          | Collect<std::vector<int>>();
+          | Collect<std::vector>();
     };
   };
 
@@ -465,7 +465,7 @@ TEST(Generator, FlatMap) {
 
   auto e = [&]() {
     return stream()
-        | Collect<std::vector<int>>();
+        | Collect<std::vector>();
   };
 
   EXPECT_THAT(*e(), ElementsAre(0, 0, 1, 0, 1, 2));
@@ -481,7 +481,7 @@ TEST(Generator, ConstRef) {
 
   auto e = [&]() {
     return stream()
-        | Collect<std::vector<int>>();
+        | Collect<std::vector>();
   };
 
   EXPECT_THAT(*e(), ElementsAre(1, 2, 3));
@@ -507,7 +507,7 @@ TEST(Generator, FromTo) {
   auto e = [&]() {
     return Just(std::string("123"))
         | stream()
-        | Collect<std::vector<int>>();
+        | Collect<std::vector>();
   };
 
   EXPECT_THAT(*e(), ElementsAre(1, 2, 3));
@@ -531,7 +531,7 @@ TEST(Generator, FromToLValue) {
   auto e = [&]() {
     return Just(std::string("123"))
         | stream()
-        | Collect<std::vector<int>>();
+        | Collect<std::vector>();
   };
 
   EXPECT_THAT(*e(), ElementsAre(1, 2, 3));
@@ -550,7 +550,7 @@ TEST(Generator, Raises) {
 
   auto e = [&]() {
     return stream()
-        | Collect<std::vector<int>>();
+        | Collect<std::vector>();
   };
 
   static_assert(

--- a/test/pipe.cc
+++ b/test/pipe.cc
@@ -21,7 +21,7 @@ TEST(Pipe, UniqueValue) {
 
   auto e = [&pipe]() {
     return pipe.Read()
-        | Collect<std::vector<int>>();
+        | Collect<std::vector>();
   };
 
   EXPECT_THAT(*e(), ElementsAre(1));
@@ -40,7 +40,7 @@ TEST(Pipe, Values) {
 
   auto e = [&pipe]() {
     return pipe.Read()
-        | Collect<std::vector<int>>();
+        | Collect<std::vector>();
   };
 
   EXPECT_THAT(*e(), ElementsAre(1, 2, 3, 4, 5));
@@ -59,7 +59,7 @@ TEST(Pipe, Close) {
 
   auto e = [&pipe]() {
     return pipe.Read()
-        | Collect<std::vector<int>>();
+        | Collect<std::vector>();
   };
 
   EXPECT_THAT(*e(), ElementsAre(1, 2));
@@ -75,7 +75,7 @@ TEST(Pipe, Size) {
 
   auto e = [&pipe]() {
     return pipe.Read()
-        | Collect<std::vector<std::string>>();
+        | Collect<std::vector>();
   };
 
   EXPECT_EQ(*pipe.Size(), 2);

--- a/test/protobuf/collect.cc
+++ b/test/protobuf/collect.cc
@@ -14,7 +14,7 @@ TEST(Collect, VectorToRepeatedPtrField) {
 
   auto s = [&]() {
     return Iterate(v)
-        | Collect<google::protobuf::RepeatedPtrField<std::string>>();
+        | Collect<google::protobuf::RepeatedPtrField>();
   };
 
   google::protobuf::RepeatedPtrField<std::string> result = *s();
@@ -42,7 +42,7 @@ TEST(Collect, MoveValueIntoRepeatedPtrField) {
                    k.Ended();
                  }
                })
-        | Collect<google::protobuf::RepeatedPtrField<std::string>>();
+        | Collect<google::protobuf::RepeatedPtrField>();
   };
 
   google::protobuf::RepeatedPtrField<std::string> result = *s();
@@ -59,7 +59,7 @@ TEST(Collect, VectorToRepeatedField) {
 
   auto s = [&]() {
     return Iterate(v)
-        | Collect<google::protobuf::RepeatedField<int>>();
+        | Collect<google::protobuf::RepeatedField>();
   };
 
   google::protobuf::RepeatedField<int> result = *s();

--- a/test/range.cc
+++ b/test/range.cc
@@ -14,77 +14,77 @@ using testing::ElementsAre;
 
 TEST(Range, CommonFlow) {
   auto s = Range(0, 5)
-      | Collect<std::vector<int>>();
+      | Collect<std::vector>();
 
   EXPECT_THAT(*s, ElementsAre(0, 1, 2, 3, 4));
 }
 
 TEST(Range, IncorrectSetup) {
   auto s = Range(2, 0)
-      | Collect<std::vector<int>>();
+      | Collect<std::vector>();
 
   EXPECT_THAT(*s, ElementsAre());
 }
 
 TEST(Range, NegativeRange) {
   auto s = Range(-2, 2)
-      | Collect<std::vector<int>>();
+      | Collect<std::vector>();
 
   EXPECT_THAT(*s, ElementsAre(-2, -1, 0, 1));
 }
 
 TEST(Range, NegativeFrom) {
   auto s = Range(-2)
-      | Collect<std::vector<int>>();
+      | Collect<std::vector>();
 
   EXPECT_THAT(*s, ElementsAre());
 }
 
 TEST(Range, DefaultFrom) {
   auto s = Range(3)
-      | Collect<std::vector<int>>();
+      | Collect<std::vector>();
 
   EXPECT_THAT(*s, ElementsAre(0, 1, 2));
 }
 
 TEST(Range, SpecifiedStep) {
   auto s = Range(0, 10, 2)
-      | Collect<std::vector<int>>();
+      | Collect<std::vector>();
 
   EXPECT_THAT(*s, ElementsAre(0, 2, 4, 6, 8));
 }
 
 TEST(Range, SpecifiedNegativeStep) {
   auto s = Range(10, 0, -2)
-      | Collect<std::vector<int>>();
+      | Collect<std::vector>();
 
   EXPECT_THAT(*s, ElementsAre(10, 8, 6, 4, 2));
 }
 
 TEST(Range, SpecifiedStepIncorrect) {
   auto s = Range(10, 0, 2)
-      | Collect<std::vector<int>>();
+      | Collect<std::vector>();
 
   EXPECT_THAT(*s, ElementsAre());
 }
 
 TEST(Range, SpecifiedStepIncorrectNegative) {
   auto s = Range(0, -10, 2)
-      | Collect<std::vector<int>>();
+      | Collect<std::vector>();
 
   EXPECT_THAT(*s, ElementsAre());
 }
 
 TEST(Range, SpecifiedIncorrect) {
   auto s = Range(0, 10, -2)
-      | Collect<std::vector<int>>();
+      | Collect<std::vector>();
 
   EXPECT_THAT(*s, ElementsAre());
 }
 
 TEST(Range, SpecifiedStepNegative) {
   auto s = Range(0, -10, -2)
-      | Collect<std::vector<int>>();
+      | Collect<std::vector>();
 
   EXPECT_THAT(*s, ElementsAre(0, -2, -4, -6, -8));
 }

--- a/test/static-thread-pool.cc
+++ b/test/static-thread-pool.cc
@@ -217,7 +217,7 @@ TEST(StaticThreadPoolTest, Concurrent) {
                   return i;
                 });
               })
-            | Collect<std::vector<int>>());
+            | Collect<std::vector>());
   };
 
   EXPECT_THAT(*e(), UnorderedElementsAre(1, 2, 3));

--- a/test/take.cc
+++ b/test/take.cc
@@ -20,7 +20,7 @@ TEST(Take, IterateTakeLastCollect) {
   auto s = [&]() {
     return Iterate(v)
         | TakeLastN(2)
-        | Collect<std::vector<int>>();
+        | Collect<std::vector>();
   };
 
   EXPECT_THAT(*s(), ElementsAre(17, 3));
@@ -32,7 +32,7 @@ TEST(Take, IterateTakeLastAllCollect) {
   auto s = [&]() {
     return Iterate(v)
         | TakeLastN(4)
-        | Collect<std::vector<int>>();
+        | Collect<std::vector>();
   };
 
   EXPECT_THAT(*s(), ElementsAre(5, 12, 17, 3));
@@ -44,7 +44,7 @@ TEST(Take, IterateTakeRangeCollect) {
   auto s = [&]() {
     return Iterate(v)
         | TakeRange(1, 2)
-        | Collect<std::vector<int>>();
+        | Collect<std::vector>();
   };
 
   EXPECT_THAT(*s(), ElementsAre(12, 17));
@@ -57,7 +57,7 @@ TEST(Take, IterateTakeRangeFilterCollect) {
     return Iterate(v)
         | TakeRange(1, 2)
         | Filter([](int x) { return x % 2 == 0; })
-        | Collect<std::vector<int>>();
+        | Collect<std::vector>();
   };
 
   EXPECT_THAT(*s(), ElementsAre(12));
@@ -69,7 +69,7 @@ TEST(Take, IterateTakeFirstCollect) {
   auto s = [&]() {
     return Iterate(v)
         | TakeFirstN(3)
-        | Collect<std::vector<int>>();
+        | Collect<std::vector>();
   };
 
   EXPECT_THAT(*s(), ElementsAre(5, 12, 17));
@@ -83,7 +83,7 @@ TEST(Take, IterateTakeFirstFilterCollect) {
     return Iterate(v)
         | TakeFirstN(3)
         | Filter([](int x) { return x % 2 == 1; })
-        | Collect<std::vector<int>>();
+        | Collect<std::vector>();
   };
 
   EXPECT_THAT(*s(), ElementsAre(5, 17));
@@ -95,7 +95,7 @@ TEST(Take, TakeLastOutOfRange) {
   auto s = [&]() {
     return Iterate(v)
         | TakeLastN(100)
-        | Collect<std::vector<int>>();
+        | Collect<std::vector>();
   };
 
   EXPECT_THAT(*s(), ElementsAre(5, 12, 17, 3));
@@ -107,7 +107,7 @@ TEST(Take, TakeFirstOutOfRange) {
   auto s = [&]() {
     return Iterate(v)
         | TakeFirstN(100)
-        | Collect<std::vector<int>>();
+        | Collect<std::vector>();
   };
 
   EXPECT_THAT(*s(), ElementsAre(5, 12, 17, 3));
@@ -119,7 +119,7 @@ TEST(Take, TakeRangeStartOutOfRange) {
   auto s = [&]() {
     return Iterate(v)
         | TakeRange(100, 100)
-        | Collect<std::vector<int>>();
+        | Collect<std::vector>();
   };
 
   EXPECT_THAT(*s(), ElementsAre());
@@ -131,7 +131,7 @@ TEST(Take, TakeRangeAmountOutOfRange) {
   auto s = [&]() {
     return Iterate(v)
         | TakeRange(1, 100)
-        | Collect<std::vector<std::string>>();
+        | Collect<std::vector>();
   };
 
   EXPECT_THAT(*s(), ElementsAre("12", "17", "3"));
@@ -146,7 +146,7 @@ TEST(Take, UniquePtr) {
   auto s = [&]() {
     return Iterate(std::move(v))
         | TakeRange(0, 100)
-        | Collect<std::vector<std::unique_ptr<int>>>();
+        | Collect<std::vector>();
   };
 
   auto result = *s();

--- a/test/transformer.cc
+++ b/test/transformer.cc
@@ -37,7 +37,7 @@ TEST(Transformer, Succeed) {
         | Map([](std::string s) {
              return s;
            })
-        | Collect<std::vector<std::string>>();
+        | Collect<std::vector>();
   };
 
   EXPECT_THAT(*e(), ElementsAre("100"));
@@ -69,7 +69,7 @@ TEST(Transformer, Stop) {
              map_start.Call();
              return s;
            })
-        | Collect<std::vector<std::string>>();
+        | Collect<std::vector>();
   };
 
   EXPECT_THROW(*e(), eventuals::StoppedException);
@@ -102,7 +102,7 @@ TEST(Transformer, Fail) {
              map_start.Call();
              return s;
            })
-        | Collect<std::vector<std::string>>();
+        | Collect<std::vector>();
   };
 
   static_assert(
@@ -158,7 +158,7 @@ TEST(Transformer, Interrupt) {
              map_start.Call();
              return s;
            })
-        | Collect<std::vector<std::string>>();
+        | Collect<std::vector>();
   };
 
   Interrupt interrupt;
@@ -197,7 +197,7 @@ TEST(Transformer, PropagateStop) {
              map_start.Call();
              return s;
            })
-        | Collect<std::vector<std::string>>();
+        | Collect<std::vector>();
   };
 
   EXPECT_THROW(*e(), eventuals::StoppedException);
@@ -229,7 +229,7 @@ TEST(Transformer, PropagateFail) {
              map_start.Call();
              return s;
            })
-        | Collect<std::vector<std::string>>();
+        | Collect<std::vector>();
   };
 
   static_assert(

--- a/test/type-check.cc
+++ b/test/type-check.cc
@@ -15,7 +15,7 @@ TEST(TypeCheck, Lvalue) {
 
   auto s = [&]() {
     return TypeCheck<int&>(Iterate(v))
-        | Collect<std::vector<int>>();
+        | Collect<std::vector>();
   };
 
   EXPECT_EQ(v, *s());
@@ -25,7 +25,7 @@ TEST(TypeCheck, Lvalue) {
 TEST(TypeCheck, Rvalue) {
   auto s = []() {
     return TypeCheck<int>(Iterate(std::vector<int>({5, 12})))
-        | Collect<std::vector<int>>();
+        | Collect<std::vector>();
   };
 
   EXPECT_EQ(std::vector<int>({5, 12}), *s());


### PR DESCRIPTION
Addresses https://github.com/3rdparty/eventuals/issues/486.

There's one specific test in `test/flat-map.cc` that worked before because we put the collection into the context of the `Loop`, that's why we could access the collection inside the `.stop` function. With the current implementation this doesn't work (though it's possible to make it work, but it would go against what we currently have in other `Eventuals` (No `Stop` method passes anything into the `k.Stop()`)). What are your thoughts on this test, @benh?

For now, I commented out this test.