### PR TITLE
Switch bazel remote cache to a multi-region bucket

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -60,7 +60,7 @@ build:windows --copt=-DNOGDI
 build:windows --host_copt=-DNOGDI
 
 # Google cache read-only access.
-build --remote_cache=https://storage.googleapis.com/reboot-dev-eventuals-remote-cache
+build --remote_cache=https://storage.googleapis.com/reboot-dev-bazel-remote-cache-eventuals-us
 build --remote_upload_local_results=false
 # Default timeout of 60 seconds is too long and bazel doesn't try to build
 # things locally while waiting for the timeout.


### PR DESCRIPTION
This should hopefully reduce the number of timeouts we're seeing when
running builds from systems in various locations. e.g. per
https://github.com/reboot-dev/respect/issues/698#issuecomment-1195302008
this should allow builds run from GitHub Codespaces (and presumably
GitHub Actions Runner) to access a remote cache storage bucket that's
closer to that system, which should hopefully reduce network latency and
improve reliability.

Should improve https://github.com/3rdparty/eventuals/issues/293.

TESTED=`dazel test //...` works from my codespace.
