### PR TITLE
Add `IsClosed` to `Pipe`

### DIFF
--- a/eventuals/pipe.h
+++ b/eventuals/pipe.h
@@ -75,6 +75,12 @@ class Pipe final : public Synchronizable {
     }));
   }
 
+  [[nodiscard]] auto IsClosed() {
+    return Synchronized(Then([this]() {
+      return is_closed_;
+    }));
+  }
+
  private:
   ConditionVariable has_values_or_closed_;
   std::deque<T> values_;


### PR DESCRIPTION
I sure would love to be able to break a loop I have (independent of a `Pipe`) on the condition that the pipe has been closed. I.e., I'd love to write code like this:
```c++
Repeat()
  >> Map([]{ ... })
  >> Until([&this]() {
       return pipe_.IsClosed();
     })
  >> Loop();
```

Before this commit, it does not seem possible as `Pipe<>::is_closed_` is not accessible. This commit adds a public eventuals wrapped accessor to expose this value and allow for the above code.