### PR TITLE
Introduce 'RequestResponseChannel'

### DIFF
--- a/eventuals/BUILD.bazel
+++ b/eventuals/BUILD.bazel
@@ -44,6 +44,7 @@ cc_library(
         "range.h",
         "reduce.h",
         "repeat.h",
+        "request-response-channel.h",
         "scheduler.h",
         "semaphore.h",
         "sequence.h",

--- a/eventuals/request-response-channel.h
+++ b/eventuals/request-response-channel.h
@@ -1,0 +1,160 @@
+#pragma once
+
+#include <deque>
+
+#include "eventuals/callback.h"
+#include "eventuals/just.h"
+#include "eventuals/lock.h"
+#include "eventuals/map.h"
+#include "eventuals/repeat.h"
+#include "eventuals/then.h"
+#include "eventuals/until.h"
+
+////////////////////////////////////////////////////////////////////////
+
+namespace eventuals {
+
+////////////////////////////////////////////////////////////////////////
+
+// A "request/response" channel is an abstraction that synchronizes making
+// a request and receiving a corresponding response.
+//
+// A "reader" of the channel does a 'Read()' to stream requests and for each
+// request read they can respond by calling 'Respond()' which will correctly
+// correspond to the read request as long as it is done in the same order as
+// the request was read.
+//
+// Requests can also be read in batch via 'ReadBatch()' and responded in batch
+// via 'RespondBatch()'.
+//
+// Requestors receive back a 'std::optional<Response>' to distinquish when a
+// channel is shutdown.
+template <typename Request_, typename Response_>
+class RequestResponseChannel final : public Synchronizable {
+ public:
+  RequestResponseChannel()
+    : has_requests_or_shutdown_(&lock()),
+      has_responses_or_shutdown_(&lock()) {}
+
+  ~RequestResponseChannel() override = default;
+
+  [[nodiscard]] auto Request(Request_&& request) {
+    return Synchronized(
+        Then([this, request = std::move(request)]() mutable {
+          if (!shutdown_) {
+            requests_.emplace_back(std::move(request));
+            has_requests_or_shutdown_.Notify();
+          }
+
+          return has_responses_or_shutdown_.Wait([this]() {
+            return responses_.empty() && !shutdown_;
+          });
+        })
+        >> Then([this]() {
+            if (!responses_.empty()) {
+              Response_ response = std::move(responses_.front());
+              responses_.pop_front();
+              return std::make_optional(std::move(response));
+            } else {
+              CHECK(shutdown_);
+              return std::optional<Response_>();
+            }
+          }));
+  }
+
+  [[nodiscard]] auto Respond(Response_&& response) {
+    return Synchronized(
+        Then([this, response = std::move(response)]() mutable {
+          if (!shutdown_) {
+            responses_.emplace_back(std::move(response));
+            has_responses_or_shutdown_.Notify();
+          }
+        }));
+  }
+
+  [[nodiscard]] auto RespondBatch(std::deque<Response_>&& responses) {
+    return Synchronized(
+        Then([this, responses = std::move(responses)]() mutable {
+          // TODO(benh): raise an error if already shutdown?
+          if (!shutdown_) {
+            for (Response_& response : responses) {
+              responses_.emplace_back(std::move(response));
+            }
+            has_responses_or_shutdown_.NotifyAll();
+          }
+        }));
+  }
+
+  [[nodiscard]] auto Read() {
+    return Repeat()
+        >> Synchronized(
+               Map([this]() {
+                 return has_requests_or_shutdown_.Wait([this]() {
+                   return requests_.empty() && !shutdown_;
+                 });
+               })
+               >> Map([this]() {
+                   if (!requests_.empty()) {
+                     Request_ request = std::move(requests_.front());
+                     requests_.pop_front();
+                     return std::make_optional(std::move(request));
+                   } else {
+                     CHECK(shutdown_);
+                     return std::optional<Request_>();
+                   }
+                 }))
+        >> Until([](std::optional<Request_>& request) {
+             return !request.has_value();
+           })
+        >> Map([](std::optional<Request_>&& request) {
+             CHECK(request);
+             // NOTE: need to use 'Just' here in case 'T' is an
+             // eventual otherwise we'll try and compose with it here!
+             return Just(std::move(*request));
+           });
+  }
+
+  // Returns an eventual 'std::optional<std::deque<Request_>>' where
+  // no value implies there are no more requests.
+  [[nodiscard]] auto ReadBatch() {
+    return Synchronized(
+        Then([this]() {
+          return has_requests_or_shutdown_.Wait([this]() {
+            return requests_.empty() && !shutdown_;
+          });
+        })
+        >> Then([this]() {
+            if (!requests_.empty()) {
+              std::deque<Request_> requests = std::move(requests_);
+              requests_.clear();
+              return std::make_optional(requests);
+            } else {
+              CHECK(shutdown_);
+              return std::optional<std::deque<Request_>>();
+            }
+          }));
+  }
+
+  // Shutdown the channel for any more requests or responses.
+  [[nodiscard]] auto Shutdown() {
+    return Synchronized(Then([this]() {
+      // TODO(benh): raise an error if already shutdown?
+      shutdown_ = true;
+      has_requests_or_shutdown_.NotifyAll();
+      has_responses_or_shutdown_.NotifyAll();
+    }));
+  }
+
+ private:
+  ConditionVariable has_requests_or_shutdown_;
+  ConditionVariable has_responses_or_shutdown_;
+  std::deque<Request_> requests_;
+  std::deque<Response_> responses_;
+  bool shutdown_ = false;
+};
+
+////////////////////////////////////////////////////////////////////////
+
+} // namespace eventuals
+
+////////////////////////////////////////////////////////////////////////

--- a/test/BUILD.bazel
+++ b/test/BUILD.bazel
@@ -71,6 +71,7 @@ cc_test(
         "poll.cc",
         "range.cc",
         "repeat.cc",
+        "request-response-channel.cc",
         "signal.cc",
         "static-thread-pool.cc",
         "stream.cc",

--- a/test/request-response-channel.cc
+++ b/test/request-response-channel.cc
@@ -1,0 +1,108 @@
+#include "eventuals/request-response-channel.h"
+
+#include <deque>
+#include <optional>
+#include <tuple>
+
+#include "eventuals/do-all.h"
+#include "eventuals/loop.h"
+#include "eventuals/map.h"
+#include "eventuals/take.h"
+#include "eventuals/then.h"
+#include "gtest/gtest.h"
+#include "test/promisify-for-test.h"
+
+using eventuals::DoAll;
+using eventuals::Loop;
+using eventuals::Map;
+using eventuals::RequestResponseChannel;
+using eventuals::TakeFirst;
+using eventuals::Then;
+
+struct Request {
+  std::string data{};
+};
+
+struct Response {
+  std::string data{};
+};
+
+TEST(RequestResponseChannel, BunchOfRequests) {
+  RequestResponseChannel<Request, Response> channel;
+
+  auto operation = [&]() {
+    return DoAll(
+        channel.Read()
+            >> TakeFirst(3)
+            >> Map([&](Request&& request) {
+                Response response{"response for " + request.data};
+                return channel.Respond(std::move(response));
+              })
+            >> Loop(),
+        Then([&]() {
+          Request request{"request1"};
+          return channel.Request(std::move(request))
+              >> Then([](std::optional<Response>&& response) {
+                   EXPECT_EQ(response->data, "response for request1");
+                 });
+        }),
+        Then([&]() {
+          Request request{"request2"};
+          return channel.Request(std::move(request))
+              >> Then([](std::optional<Response>&& response) {
+                   EXPECT_EQ(response->data, "response for request2");
+                 });
+        }),
+        Then([&]() {
+          Request request{"request3"};
+          return channel.Request(std::move(request))
+              >> Then([](std::optional<Response>&& response) {
+                   EXPECT_EQ(response->data, "response for request3");
+                 });
+        }));
+  };
+
+  EXPECT_EQ(
+      *operation(),
+      std::make_tuple(
+          std::monostate{},
+          std::monostate{},
+          std::monostate{},
+          std::monostate{}));
+}
+
+TEST(RequestResponseChannel, ReadBatch) {
+  RequestResponseChannel<Request, Response> channel;
+
+  auto read = [&]() {
+    return channel.ReadBatch()
+        >> Then([&](std::optional<std::deque<Request>>&& requests) {
+             std::deque<Response> responses;
+             for (const Request& request : *requests) {
+               responses.push_back(Response{"response for " + request.data});
+             }
+             return channel.RespondBatch(std::move(responses));
+           });
+  };
+
+  auto [future1, write1] =
+      PromisifyForTest(channel.Request(Request{"request1"}));
+
+  write1.Start();
+
+  auto [future2, write2] =
+      PromisifyForTest(channel.Request(Request{"request2"}));
+
+  write2.Start();
+
+  *read();
+
+  std::optional<Response> response1 = future1.get();
+  std::optional<Response> response2 = future2.get();
+
+  ASSERT_TRUE(response1);
+  ASSERT_TRUE(response2);
+
+  EXPECT_EQ(response1->data, "response for request1");
+  EXPECT_EQ(response2->data, "response for request2");
+}


### PR DESCRIPTION
This PR adds 'RequestResponseChannel' which is generally
speaking a synchronized "pipe in a pipe" for handling
requests and responses. So it guarantees that for every
request that is written we read a response in order.