### PR TITLE
Use `= default` where applicable. Add missing include in `eventuals/grpc/logging.h` 

### DIFF
--- a/eventuals/callback.h
+++ b/eventuals/callback.h
@@ -24,7 +24,7 @@ struct Callback<R(Args...)> final {
   // where a delayed initialization requires std::optional so that a
   // user doesn't run into issues where they try and invoke a callback
   // that doesn't go anywhere.
-  Callback() {}
+  Callback() = default;
 
   template <typename F>
   Callback(F f) {

--- a/eventuals/event-loop.h
+++ b/eventuals/event-loop.h
@@ -118,7 +118,7 @@ class EventLoop final : public Scheduler {
       return *this;
     }
 
-    ~Buffer() {}
+    ~Buffer() = default;
 
     // Extracts the data from the buffer as a universal reference.
     // Empties out the buffer inside.

--- a/eventuals/filesystem.h
+++ b/eventuals/filesystem.h
@@ -17,7 +17,7 @@ namespace filesystem {
 // Moveable, not Copyable.
 class Request final {
  public:
-  Request() {}
+  Request() = default;
 
   Request(const Request&) = delete;
   Request(Request&& that) noexcept
@@ -79,7 +79,7 @@ class File final {
   // NOTE: default constructor should not exist or be used but is
   // necessary on Windows so this type can be used as a type parameter
   // to 'std::promise', see: https://bit.ly/VisualStudioStdPromiseBug
-  File() {}
+  File() = default;
 #endif
 
   File(const File& that) = delete;

--- a/eventuals/grpc/logging.h
+++ b/eventuals/grpc/logging.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "glog/logging.h"
+
 inline bool EventualsGrpcLog(int level) {
   // TODO(benh): Initialize logging if it hasn't already been done so?
   static const char* variable = std::getenv("EVENTUALS_GRPC_LOG");

--- a/eventuals/http.h
+++ b/eventuals/http.h
@@ -393,7 +393,7 @@ class Client::_Builder final : public builder::Builder {
   friend class builder::Builder;
   friend class Client;
 
-  _Builder() {}
+  _Builder() = default;
 
   _Builder(
       builder::Field<bool, has_verify_peer_> verify_peer,

--- a/eventuals/rsa.h
+++ b/eventuals/rsa.h
@@ -135,7 +135,7 @@ class Key::_Builder final : public builder::Builder {
   friend class builder::Builder;
   friend class Key;
 
-  _Builder() {}
+  _Builder() = default;
 
   _Builder(
       builder::FieldWithDefault<int, has_bits_> bits,

--- a/eventuals/static-thread-pool.h
+++ b/eventuals/static-thread-pool.h
@@ -39,8 +39,7 @@ struct Pinned {
     return cpu_;
   }
 
-  Pinned(const Pinned& that)
-    : cpu_(that.cpu_) {}
+  Pinned(const Pinned& that) = default;
 
  private:
   Pinned() = default;

--- a/eventuals/x509.h
+++ b/eventuals/x509.h
@@ -208,7 +208,7 @@ class Certificate::_Builder final : public builder::Builder {
   friend class builder::Builder;
   friend class Certificate;
 
-  _Builder() {}
+  _Builder() = default;
 
   _Builder(
       builder::Field<rsa::Key, has_subject_key_> subject_key,


### PR DESCRIPTION
According to [clang-tidy](https://clang.llvm.org/extra/clang-tidy/checks/modernize/use-equals-default.html):
```
The explicitly defaulted function declarations enable more opportunities in optimization,
because the compiler might treat explicitly defaulted functions as trivial.
```