### PR TITLE
Construct objects using direct initialization

### DIFF
--- a/eventuals/event-loop.cc
+++ b/eventuals/event-loop.cc
@@ -147,7 +147,7 @@ bool EventLoop::HasDefault() {
 void EventLoop::ConstructDefaultAndRunForeverDetached() {
   ConstructDefault();
 
-  auto thread = std::thread([]() {
+  std::thread thread([]() {
     EventLoop::Default().RunForever();
   });
 

--- a/eventuals/grpc/server.cc
+++ b/eventuals/grpc/server.cc
@@ -85,7 +85,7 @@ auto Server::Unimplemented(ServerContext* context) {
         << "Dropping call for host " << context->host()
         << " and path = " << context->method();
 
-    auto status = ::grpc::Status(
+    ::grpc::Status status(
         ::grpc::UNIMPLEMENTED,
         context->method() + " for host " + context->host());
 

--- a/eventuals/http.h
+++ b/eventuals/http.h
@@ -599,12 +599,8 @@ struct _HTTP final {
                           }
 
                           // Assign key and value.
-                          auto key = std::string(
-                              line.cbegin(),
-                              column_iterator);
-                          auto value = std::string(
-                              column_iterator + 1,
-                              line.cend());
+                          std::string key(line.cbegin(), column_iterator);
+                          std::string value(column_iterator + 1, line.cend());
 
                           // Remove leading and trailing spaces.
                           key = absl::StripAsciiWhitespace(key);

--- a/test/conditional.cc
+++ b/test/conditional.cc
@@ -93,7 +93,7 @@ TEST(ConditionalTest, Fail) {
     return Eventual<int>()
                .raises<std::runtime_error>()
                .start([](auto& k) {
-                 auto thread = std::thread(
+                 std::thread thread(
                      [&k]() mutable {
                        k.Fail(std::runtime_error("error"));
                      });

--- a/test/eventual.cc
+++ b/test/eventual.cc
@@ -35,7 +35,7 @@ TEST(EventualTest, Succeed) {
     return Eventual<int>()
                .context(5)
                .start([](auto& context, auto& k) {
-                 auto thread = std::thread(
+                 std::thread thread(
                      [&context, &k]() mutable {
                        k.Start(context);
                      });
@@ -45,7 +45,7 @@ TEST(EventualTest, Succeed) {
         >> Eventual<int>()
                .context(9)
                .start([](auto& context, auto& k, auto&& value) {
-                 auto thread = std::thread(
+                 std::thread thread(
                      [value, &context, &k]() mutable {
                        k.Start(context - value);
                      });
@@ -78,7 +78,7 @@ TEST(EventualTest, Fail) {
                .raises()
                .context("error")
                .start([](auto& error, auto& k) {
-                 auto thread = std::thread(
+                 std::thread thread(
                      [&error, &k]() mutable {
                        k.Fail(std::runtime_error(error));
                      });
@@ -154,7 +154,7 @@ TEST(EventualTest, Reuse) {
     return (Eventual<int>()
                 .context(i)
                 .start([](auto& context, auto& k) {
-                  auto thread = std::thread(
+                  std::thread thread(
                       [&context, &k]() mutable {
                         k.Start(context);
                       });
@@ -164,7 +164,7 @@ TEST(EventualTest, Reuse) {
         >> Eventual<int>()
                .context(9)
                .start([](auto& context, auto& k, auto&& value) {
-                 auto thread = std::thread(
+                 std::thread thread(
                      [value, &context, &k]() mutable {
                        k.Start(context - value);
                      });

--- a/test/lock.cc
+++ b/test/lock.cc
@@ -26,7 +26,7 @@ TEST(LockTest, Succeed) {
   auto e1 = [&]() {
     return Eventual<std::string>()
                .start([](auto& k) {
-                 auto thread = std::thread(
+                 std::thread thread(
                      [&k]() mutable {
                        k.Start("t1");
                      });
@@ -39,7 +39,7 @@ TEST(LockTest, Succeed) {
   auto e2 = [&]() {
     return Eventual<std::string>()
                .start([](auto& k) {
-                 auto thread = std::thread(
+                 std::thread thread(
                      [&k]() mutable {
                        k.Start("t2");
                      });
@@ -80,7 +80,7 @@ TEST(LockTest, Fail) {
         >> Eventual<std::string>()
                .raises<std::runtime_error>()
                .start([](auto& k) {
-                 auto thread = std::thread(
+                 std::thread thread(
                      [&k]() mutable {
                        k.Fail(std::runtime_error("error"));
                      });

--- a/test/static-thread-pool.cc
+++ b/test/static-thread-pool.cc
@@ -59,7 +59,7 @@ TEST(StaticThreadPoolTest, Reschedulable) {
           return Eventual<void>()
                      .start([&id](auto& k) {
                        EXPECT_EQ(id, std::this_thread::get_id());
-                       auto thread = std::thread(
+                       std::thread thread(
                            [&id, &k]() {
                              EXPECT_NE(id, std::this_thread::get_id());
                              k.Start();
@@ -133,7 +133,7 @@ TEST(StaticThreadPoolTest, Spawn) {
           return Eventual<void>()
                      .start([&id](auto& k) {
                        EXPECT_EQ(id, std::this_thread::get_id());
-                       auto thread = std::thread(
+                       std::thread thread(
                            [&id, &k]() {
                              EXPECT_NE(id, std::this_thread::get_id());
                              k.Start();
@@ -167,7 +167,7 @@ TEST(StaticThreadPoolTest, SpawnFail) {
                      .raises<std::runtime_error>()
                      .start([&id](auto& k) {
                        EXPECT_EQ(id, std::this_thread::get_id());
-                       auto thread = std::thread(
+                       std::thread thread(
                            [&id, &k]() {
                              EXPECT_NE(id, std::this_thread::get_id());
                              k.Fail(std::runtime_error("error"));

--- a/test/stream.cc
+++ b/test/stream.cc
@@ -205,7 +205,7 @@ TEST(StreamTest, InterruptStream) {
                })
         >> Loop<int>()
                .body([&](auto& k, auto&&) {
-                 auto thread = std::thread(
+                 std::thread thread(
                      [&]() mutable {
                        while (!triggered.load()) {
                          std::this_thread::yield();
@@ -275,7 +275,7 @@ TEST(StreamTest, InterruptLoop) {
                  k.Next();
                })
                .body([&](auto&, auto& k, auto&, auto&&) {
-                 auto thread = std::thread(
+                 std::thread thread(
                      [&]() mutable {
                        while (!triggered.load()) {
                          std::this_thread::yield();

--- a/test/then.cc
+++ b/test/then.cc
@@ -27,7 +27,7 @@ TEST(ThenTest, Succeed) {
     return Eventual<int>()
                .context(1)
                .start([](auto& value, auto& k) {
-                 auto thread = std::thread(
+                 std::thread thread(
                      [&value, &k]() mutable {
                        k.Start(value);
                      });
@@ -71,7 +71,7 @@ TEST(ThenTest, Fail) {
     return Eventual<int>()
                .raises<std::runtime_error>()
                .start([](auto& k) {
-                 auto thread = std::thread(
+                 std::thread thread(
                      [&k]() mutable {
                        k.Fail(std::runtime_error("error"));
                      });

--- a/test/timer.cc
+++ b/test/timer.cc
@@ -107,7 +107,7 @@ TEST_F(EventLoopTest, InterruptTimer) {
 
   k.Start();
 
-  auto thread = std::thread([&]() {
+  std::thread thread([&]() {
     interrupt.Trigger();
   });
 


### PR DESCRIPTION
Direct initialization is simpler than copy initialization, and shorter
(you don't need to specify the type / constructor name on both the LHS
and RHS of the initialization line).

These two forms should have the same effect in C++17:
https://stackoverflow.com/a/41891708 pre-C++17, direct initialization
was typically faster / simpler (since copy initialization might incur
copies).
