### PR TITLE
Explicit definition of all ctrs, operator= and dstrs

### DIFF
--- a/eventuals/builder.h
+++ b/eventuals/builder.h
@@ -18,6 +18,14 @@ class Field;
 template <typename Value_>
 class Field<Value_, false> {
  public:
+  Field() = default;
+
+  Field(const Field&) = default;
+  Field(Field&&) noexcept = default;
+
+  Field& operator=(const Field&) = default;
+  Field& operator=(Field&&) noexcept = default;
+
   virtual ~Field() = default;
 
   template <typename... Args>
@@ -32,6 +40,12 @@ class Field<Value_, true> {
  public:
   Field(Value_ value)
     : value_(std::move(value)) {}
+
+  Field(const Field&) = default;
+  Field(Field&&) noexcept = default;
+
+  Field& operator=(const Field&) = default;
+  Field& operator=(Field&&) noexcept = default;
 
   virtual ~Field() = default;
 
@@ -77,7 +91,11 @@ class FieldWithDefault<Value_, false> final : public Field<Value_, false> {
   FieldWithDefault(Value&& value)
     : default_(std::forward<Value>(value)) {}
 
+  FieldWithDefault(const FieldWithDefault&) = delete;
   FieldWithDefault(FieldWithDefault&&) noexcept = default;
+
+  FieldWithDefault& operator=(const FieldWithDefault&) = delete;
+  FieldWithDefault& operator=(FieldWithDefault&&) noexcept = delete;
 
   ~FieldWithDefault() override = default;
 
@@ -124,7 +142,11 @@ class FieldWithDefault<Value_, true> final : public Field<Value_, true> {
   FieldWithDefault(Value&& value)
     : Field<Value_, true>(std::forward<Value>(value)) {}
 
+  FieldWithDefault(const FieldWithDefault&) = delete;
   FieldWithDefault(FieldWithDefault&&) noexcept = default;
+
+  FieldWithDefault& operator=(const FieldWithDefault&) = delete;
+  FieldWithDefault& operator=(FieldWithDefault&&) noexcept = delete;
 
   ~FieldWithDefault() override = default;
 };
@@ -143,7 +165,11 @@ class RepeatedField<Value_, false> final : public Field<Value_, false> {
   RepeatedField(Value&& value)
     : default_(std::forward<Value>(value)) {}
 
+  RepeatedField(const RepeatedField&) = delete;
   RepeatedField(RepeatedField&&) noexcept = default;
+
+  RepeatedField& operator=(const RepeatedField&) = delete;
+  RepeatedField& operator=(RepeatedField&&) noexcept = delete;
 
   ~RepeatedField() override = default;
 
@@ -190,7 +216,11 @@ class RepeatedField<Value_, true> final : public Field<Value_, true> {
   RepeatedField(Value&& value)
     : Field<Value_, true>(std::forward<Value>(value)) {}
 
+  RepeatedField(const RepeatedField&) = delete;
   RepeatedField(RepeatedField&&) noexcept = default;
+
+  RepeatedField& operator=(const RepeatedField&) = delete;
+  RepeatedField& operator=(RepeatedField&&) noexcept = delete;
 
   ~RepeatedField() override = default;
 
@@ -205,6 +235,14 @@ class RepeatedField<Value_, true> final : public Field<Value_, true> {
 
 class Builder {
  public:
+  Builder() = default;
+
+  Builder(const Builder&) = default;
+  Builder(Builder&&) noexcept = default;
+
+  Builder& operator=(const Builder&) = default;
+  Builder& operator=(Builder&&) noexcept = default;
+
   virtual ~Builder() = default;
 
  protected:

--- a/eventuals/callback.h
+++ b/eventuals/callback.h
@@ -35,6 +35,18 @@ struct Callback<R(Args...)> final {
     this->operator=(std::move(f));
   }
 
+  Callback(const Callback&) = delete;
+
+  Callback(Callback&& that) noexcept {
+    if (that.base_ != nullptr) {
+      base_ = that.base_->Move(&storage_);
+
+      // Set 'base_' to nullptr so we only destruct once.
+      that.base_ = nullptr;
+    }
+  }
+
+  Callback& operator=(const Callback&) = delete;
   Callback& operator=(Callback&& that) noexcept {
     if (this == &that) {
       return *this;
@@ -77,15 +89,6 @@ struct Callback<R(Args...)> final {
     return *this;
   }
 
-  Callback(Callback&& that) noexcept {
-    if (that.base_ != nullptr) {
-      base_ = that.base_->Move(&storage_);
-
-      // Set 'base_' to nullptr so we only destruct once.
-      that.base_ = nullptr;
-    }
-  }
-
   ~Callback() {
     if (base_ != nullptr) {
       base_->~Base();
@@ -102,6 +105,14 @@ struct Callback<R(Args...)> final {
   }
 
   struct Base {
+    Base() = default;
+
+    Base(const Base&) = default;
+    Base(Base&&) noexcept = default;
+
+    Base& operator=(const Base&) = default;
+    Base& operator=(Base&&) noexcept = default;
+
     virtual ~Base() = default;
 
     virtual R Invoke(Args... args) = 0;
@@ -113,6 +124,12 @@ struct Callback<R(Args...)> final {
   struct Handler final : Base {
     Handler(F f)
       : f_(std::move(f)) {}
+
+    Handler(const Handler&) = default;
+    Handler(Handler&&) noexcept = default;
+
+    Handler& operator=(const Handler&) = default;
+    Handler& operator=(Handler&&) noexcept = default;
 
     ~Handler() override = default;
 

--- a/eventuals/concurrent-ordered.h
+++ b/eventuals/concurrent-ordered.h
@@ -26,7 +26,11 @@ struct _ReorderAdaptor final {
     Continuation(K_ k)
       : k_(std::move(k)) {}
 
+    Continuation(const Continuation&) = delete;
     Continuation(Continuation&& that) noexcept = default;
+
+    Continuation& operator=(const Continuation&) = delete;
+    Continuation& operator=(Continuation&&) noexcept = delete;
 
     ~Continuation() override = default;
 
@@ -149,6 +153,12 @@ struct _ConcurrentOrderedAdaptor final {
   struct Continuation final : public TypeErasedStream {
     Continuation(K_ k)
       : k_(std::move(k)) {}
+
+    Continuation(const Continuation&) = default;
+    Continuation(Continuation&&) noexcept = default;
+
+    Continuation& operator=(const Continuation&) = default;
+    Continuation& operator=(Continuation&&) noexcept = default;
 
     ~Continuation() override = default;
 

--- a/eventuals/concurrent.h
+++ b/eventuals/concurrent.h
@@ -70,6 +70,20 @@ struct _Concurrent final {
     // that have completed but haven't yet been pruned (see
     // 'CreateOrReuseFiber()').
     struct TypeErasedFiber {
+      TypeErasedFiber() = default;
+
+      // Constructors and assignment operators are deleted, because
+      // 'Interrupt' class has std::atomic (which is not copyable/moveable),
+      // and doesn't provide its own copy/move constructors/assignment
+      // operators.
+      TypeErasedFiber(const TypeErasedFiber&) = delete;
+      TypeErasedFiber(TypeErasedFiber&&) noexcept = delete;
+
+      TypeErasedFiber& operator=(const TypeErasedFiber&) = delete;
+      TypeErasedFiber& operator=(TypeErasedFiber&&) = delete;
+
+      virtual ~TypeErasedFiber() = default;
+
       void Reuse() {
         done = false;
         // Need to reinitialize the interrupt so that the
@@ -78,8 +92,6 @@ struct _Concurrent final {
         interrupt.~Interrupt();
         new (&interrupt) class Interrupt();
       }
-
-      virtual ~TypeErasedFiber() = default;
 
       // A fiber indicates it is done with this boolean.
       bool done = false;
@@ -432,6 +444,12 @@ struct _Concurrent final {
     Adaptor(F_ f)
       : f_(std::move(f)) {}
 
+    Adaptor(const Adaptor&) = default;
+    Adaptor(Adaptor&&) noexcept = default;
+
+    Adaptor& operator=(const Adaptor&) = default;
+    Adaptor& operator=(Adaptor&&) noexcept = default;
+
     ~Adaptor() override = default;
 
     // Our typeful fiber includes the continuation 'K' that we'll
@@ -585,10 +603,15 @@ struct _Concurrent final {
       : adaptor_(std::move(f)),
         k_(std::move(k)) {}
 
+    Continuation(const Continuation&) = delete;
+
     // NOTE: explicit move-constructor because of 'std::atomic_flag'.
     Continuation(Continuation&& that) noexcept
       : adaptor_(std::move(that.adaptor_.f_)),
         k_(std::move(that.k_)) {}
+
+    Continuation& operator=(const Continuation&) = delete;
+    Continuation& operator=(Continuation&&) noexcept = delete;
 
     ~Continuation() override = default;
 

--- a/eventuals/do-all.h
+++ b/eventuals/do-all.h
@@ -21,12 +21,19 @@ struct _DoAll final {
       : k_(k),
         interrupt_(interrupt) {}
 
+    Adaptor(const Adaptor&) = delete;
+
     Adaptor(Adaptor&& that) noexcept
       : k_(that.k_),
         interrupt_(that.interrupt_) {
       CHECK(that.counter_.load() == sizeof...(Eventuals_))
           << "moving after starting is illegal";
     }
+
+    Adaptor& operator=(const Adaptor&) = delete;
+    Adaptor& operator=(Adaptor&&) noexcept = delete;
+
+    ~Adaptor() = default;
 
     K_& k_;
     Interrupt& interrupt_;
@@ -190,12 +197,19 @@ struct _DoAll final {
       : eventuals_(std::move(eventuals)),
         k_(std::move(k)) {}
 
+    Continuation(const Continuation&) = delete;
+
     Continuation(Continuation&& that) noexcept
       : eventuals_(std::move(that.eventuals_)),
         adaptor_(std::move(that.adaptor_)),
         ks_(std::move(that.ks_)),
         handler_(std::move(that.handler_)),
         k_(std::move(that.k_)) {}
+
+    Continuation& operator=(const Continuation&) = delete;
+    Continuation& operator=(Continuation&&) noexcept = delete;
+
+    ~Continuation() = default;
 
     template <typename... Args>
     void Start(Args&&...) {

--- a/eventuals/event-loop.h
+++ b/eventuals/event-loop.h
@@ -153,10 +153,16 @@ class EventLoop final : public Scheduler {
 
   class Clock final : public stout::enable_borrowable_from_this<Clock> {
    public:
-    Clock(const Clock&) = delete;
-
     Clock(EventLoop& loop)
       : loop_(loop) {}
+
+    Clock(const Clock&) = delete;
+    Clock(Clock&&) noexcept = delete;
+
+    Clock& operator=(const Clock&) = delete;
+    Clock& operator=(Clock&&) noexcept = delete;
+
+    ~Clock() override = default;
 
     std::chrono::nanoseconds Now();
 
@@ -204,6 +210,8 @@ class EventLoop final : public Scheduler {
             interrupt_context_(&clock_->loop(), "Timer (interrupt)"),
             k_(std::move(k)) {}
 
+        Continuation(const Continuation&) = delete;
+
         Continuation(Continuation&& that) noexcept
           : clock_(std::move(that.clock_)),
             nanoseconds_(std::move(that.nanoseconds_)),
@@ -213,6 +221,9 @@ class EventLoop final : public Scheduler {
           CHECK(!that.started_ || !that.completed_) << "moving after starting";
           CHECK(!handler_);
         }
+
+        Continuation& operator=(const Continuation&) = delete;
+        Continuation& operator=(Continuation&&) noexcept = delete;
 
         ~Continuation() {
           CHECK(!started_ || closed_);
@@ -462,7 +473,13 @@ class EventLoop final : public Scheduler {
   static void ConstructDefaultAndRunForeverDetached();
 
   EventLoop();
+
   EventLoop(const EventLoop&) = delete;
+  EventLoop(EventLoop&&) noexcept = delete;
+
+  EventLoop& operator=(const EventLoop&) = delete;
+  EventLoop& operator=(EventLoop&&) noexcept = delete;
+
   ~EventLoop() override;
 
   void RunForever();
@@ -555,6 +572,8 @@ class EventLoop final : public Scheduler {
           interrupt_context_(&loop, "WaitForSignal (interrupt)"),
           k_(std::move(k)) {}
 
+      Continuation(const Continuation&) = delete;
+
       Continuation(Continuation&& that) noexcept
         : loop_(that.loop_),
           signum_(that.signum_),
@@ -564,6 +583,9 @@ class EventLoop final : public Scheduler {
         CHECK(!that.started_ || !that.completed_) << "moving after starting";
         CHECK(!handler_);
       }
+
+      Continuation& operator=(const Continuation&) = delete;
+      Continuation& operator=(Continuation&&) noexcept = delete;
 
       ~Continuation() {
         CHECK(!started_ || closed_);
@@ -775,6 +797,8 @@ class EventLoop final : public Scheduler {
           interrupt_context_(&loop, "Poll (interrupt)"),
           k_(std::move(k)) {}
 
+      Continuation(const Continuation&) = delete;
+
       Continuation(Continuation&& that) noexcept
         : loop_(that.loop_),
           fd_(that.fd_),
@@ -785,6 +809,9 @@ class EventLoop final : public Scheduler {
         CHECK(!that.started_ || !that.completed_) << "moving after starting";
         CHECK(!handler_);
       }
+
+      Continuation& operator=(const Continuation&) = delete;
+      Continuation& operator=(Continuation&&) noexcept = delete;
 
       ~Continuation() {
         CHECK(!started_ || closed_);

--- a/eventuals/eventual.h
+++ b/eventuals/eventual.h
@@ -80,7 +80,10 @@ struct _Eventual {
         stop_(std::move(stop)),
         k_(std::move(k)) {}
 
+    Continuation(const Continuation&) = delete;
     Continuation(Continuation&& that) noexcept = default;
+
+    Continuation& operator=(const Continuation&) = delete;
 
     Continuation& operator=(Continuation&& that) noexcept {
       if (this == &that) {
@@ -96,6 +99,8 @@ struct _Eventual {
 
       return *this;
     }
+
+    ~Continuation() = default;
 
     template <typename... Args>
     void Start(Args&&... args) {

--- a/eventuals/flat-map.h
+++ b/eventuals/flat-map.h
@@ -61,7 +61,11 @@ struct _FlatMap final {
       : f_(std::move(f)),
         k_(std::move(k)) {}
 
+    Continuation(const Continuation&) = delete;
     Continuation(Continuation&& that) noexcept = default;
+
+    Continuation& operator=(const Continuation&) = delete;
+    Continuation& operator=(Continuation&&) noexcept = delete;
 
     ~Continuation() override = default;
 

--- a/eventuals/generator.h
+++ b/eventuals/generator.h
@@ -456,9 +456,13 @@ struct _Generator final {
       };
     }
 
-    ~Composable() = default;
+    Composable(const Composable&) = delete;
+    Composable(Composable&&) noexcept = default;
 
-    Composable(Composable&& that) noexcept = default;
+    Composable& operator=(const Composable&) = delete;
+    Composable& operator=(Composable&&) noexcept = delete;
+
+    ~Composable() = default;
 
     template <typename Arg, typename K>
     auto k(K k) && {

--- a/eventuals/http.cc
+++ b/eventuals/http.cc
@@ -12,6 +12,12 @@ class CURLGlobalInitializer final {
     CHECK_EQ(curl_global_init(CURL_GLOBAL_ALL), 0);
   }
 
+  CURLGlobalInitializer(const CURLGlobalInitializer&) = default;
+  CURLGlobalInitializer(CURLGlobalInitializer&&) noexcept = default;
+
+  CURLGlobalInitializer& operator=(const CURLGlobalInitializer&) = default;
+  CURLGlobalInitializer& operator=(CURLGlobalInitializer&&) noexcept = default;
+
   ~CURLGlobalInitializer() {
     curl_global_cleanup();
   }

--- a/eventuals/http.h
+++ b/eventuals/http.h
@@ -100,6 +100,12 @@ template <
     bool has_headers_>
 class Request::_Builder final : public builder::Builder {
  public:
+  _Builder(const _Builder&) = default;
+  _Builder(_Builder&&) noexcept = default;
+
+  _Builder& operator=(const _Builder&) = default;
+  _Builder& operator=(_Builder&&) noexcept = default;
+
   ~_Builder() override = default;
 
   auto uri(std::string&& uri) && {
@@ -289,6 +295,8 @@ struct Response final {
   Response& operator=(const Response&) = default;
   Response& operator=(Response&&) = default;
 
+  ~Response() = default;
+
   const auto& code() const {
     return code_;
   }
@@ -351,6 +359,12 @@ class Client final {
 template <bool has_verify_peer_, bool has_certificate_>
 class Client::_Builder final : public builder::Builder {
  public:
+  _Builder(const _Builder&) = default;
+  _Builder(_Builder&&) noexcept = default;
+
+  _Builder& operator=(const _Builder&) = default;
+  _Builder& operator=(_Builder&&) noexcept = default;
+
   ~_Builder() override = default;
 
   auto verify_peer(bool verify_peer) && {
@@ -445,6 +459,8 @@ struct _HTTP final {
         interrupt_context_(&loop_, "HTTP (interrupt)"),
         k_(std::move(k)) {}
 
+    Continuation(const Continuation&) = delete;
+
     Continuation(Continuation&& that) noexcept
       : loop_(that.loop_),
         request_(std::move(that.request_)),
@@ -458,6 +474,9 @@ struct _HTTP final {
       CHECK(!that.started_ || !that.completed_) << "moving after starting";
       CHECK(!handler_);
     }
+
+    Continuation& operator=(const Continuation&) = delete;
+    Continuation& operator=(Continuation&&) noexcept = delete;
 
     ~Continuation() {
       CHECK(!started_ || closed_);

--- a/eventuals/interrupt.h
+++ b/eventuals/interrupt.h
@@ -29,6 +29,11 @@ class Interrupt final {
       CHECK(that.next_ == nullptr);
     }
 
+    Handler& operator=(const Handler&) = delete;
+    Handler& operator=(Handler&&) noexcept = delete;
+
+    ~Handler() = default;
+
     Interrupt& interrupt() {
       return *CHECK_NOTNULL(interrupt_);
     }

--- a/eventuals/lazy.h
+++ b/eventuals/lazy.h
@@ -18,6 +18,8 @@ struct _Lazy final {
   using Args =
       std::enable_if_t<sizeof...(Args_) == 0, _Lazy<T_, Arg, Args...>>;
 
+  _Lazy(const _Lazy&) = delete;
+
   _Lazy(_Lazy&& that) noexcept
     : args_(std::move(that.args_)) {
     CHECK(!t_) << "'Lazy' can not be moved after using";
@@ -30,6 +32,11 @@ struct _Lazy final {
           int> = 0>
   _Lazy(Args&&... args)
     : args_(std::forward<Args>(args)...) {}
+
+  _Lazy& operator=(const _Lazy&) = delete;
+  _Lazy& operator=(_Lazy&&) noexcept = delete;
+
+  ~_Lazy() = default;
 
   T_* get() {
     if (!t_) {

--- a/eventuals/lock.h
+++ b/eventuals/lock.h
@@ -147,11 +147,16 @@ struct _Acquire final {
       : lock_(lock),
         k_(std::move(k)) {}
 
+    Continuation(const Continuation&) = delete;
+
     Continuation(Continuation&& that) noexcept
       : lock_(that.lock_),
         k_(std::move(that.k_)) {
       CHECK(!waiter_.context) << "moving after starting";
     }
+
+    Continuation& operator=(const Continuation&) = delete;
+    Continuation& operator=(Continuation&&) noexcept = delete;
 
     ~Continuation() {
       CHECK(!waiter_.f) << "continuation still waiting for lock";
@@ -573,7 +578,11 @@ struct _Wait final {
         f_(std::move(f)),
         k_(std::move(k)) {}
 
+    Continuation(const Continuation&) = delete;
     Continuation(Continuation&&) noexcept = default;
+
+    Continuation& operator=(const Continuation&) = delete;
+    Continuation& operator=(Continuation&&) noexcept = delete;
 
     ~Continuation() {
       CHECK(!waiting_) << "continuation still waiting for lock";
@@ -815,6 +824,18 @@ template <typename F>
 
 class Synchronizable {
  public:
+  Synchronizable() = default;
+
+  // Constructors and assignment operators are deleted, because
+  // 'Lock' class has std::atomic (which is not copyable/moveable),
+  // and doesn't provide its own copy/move constructors/assignment
+  // operators.
+  Synchronizable(const Synchronizable&) = delete;
+  Synchronizable(Synchronizable&&) noexcept = delete;
+
+  Synchronizable& operator=(const Synchronizable&) = delete;
+  Synchronizable& operator=(Synchronizable&&) noexcept = delete;
+
   virtual ~Synchronizable() = default;
 
   template <typename E>

--- a/eventuals/loop.h
+++ b/eventuals/loop.h
@@ -84,7 +84,10 @@ struct _Loop final {
         stop_(std::move(stop)),
         k_(std::move(k)) {}
 
+    Continuation(const Continuation&) = delete;
     Continuation(Continuation&& that) noexcept = default;
+
+    Continuation& operator=(const Continuation&) = delete;
 
     Continuation& operator=(Continuation&& that) noexcept {
       if (this == &that) {
@@ -100,6 +103,8 @@ struct _Loop final {
 
       return *this;
     }
+
+    ~Continuation() = default;
 
     void Begin(TypeErasedStream& stream) {
       stream_ = &stream;

--- a/eventuals/pipe.h
+++ b/eventuals/pipe.h
@@ -22,6 +22,12 @@ class Pipe final : public Synchronizable {
   Pipe()
     : has_values_or_closed_(&lock()) {}
 
+  Pipe(const Pipe&) = default;
+  Pipe(Pipe&&) noexcept = default;
+
+  Pipe& operator=(const Pipe&) = default;
+  Pipe& operator=(Pipe&&) noexcept = default;
+
   ~Pipe() override = default;
 
   [[nodiscard]] auto Write(T&& value) {

--- a/eventuals/range.h
+++ b/eventuals/range.h
@@ -18,7 +18,11 @@ struct _Range final {
         step_(step),
         k_(std::move(k)) {}
 
+    Continuation(const Continuation&) = delete;
     Continuation(Continuation&& that) noexcept = default;
+
+    Continuation& operator=(const Continuation&) = delete;
+    Continuation& operator=(Continuation&&) noexcept = delete;
 
     ~Continuation() override = default;
 

--- a/eventuals/repeat.h
+++ b/eventuals/repeat.h
@@ -17,7 +17,11 @@ struct _Repeat final {
     Continuation(K_ k)
       : k_(std::move(k)) {}
 
+    Continuation(const Continuation&) = delete;
     Continuation(Continuation&& that) noexcept = default;
+
+    Continuation& operator=(const Continuation&) = delete;
+    Continuation& operator=(Continuation&&) noexcept = delete;
 
     ~Continuation() override = default;
 

--- a/eventuals/rsa.h
+++ b/eventuals/rsa.h
@@ -53,6 +53,8 @@ class Key final {
     return *this;
   }
 
+  ~Key() = default;
+
   bool operator==(const Key& that) const {
     return EVP_PKEY_cmp(
         CHECK_NOTNULL(key_.get()),
@@ -113,6 +115,12 @@ class Key final {
 template <bool has_bits_, bool has_exponent_>
 class Key::_Builder final : public builder::Builder {
  public:
+  _Builder(const _Builder&) = default;
+  _Builder(_Builder&&) noexcept = default;
+
+  _Builder& operator=(const _Builder&) = default;
+  _Builder& operator=(_Builder&&) noexcept = default;
+
   ~_Builder() override = default;
 
   auto bits(int bits) && {

--- a/eventuals/scheduler.cc
+++ b/eventuals/scheduler.cc
@@ -12,6 +12,14 @@ namespace eventuals {
 
 class DefaultScheduler final : public Scheduler {
  public:
+  DefaultScheduler() = default;
+
+  DefaultScheduler(const DefaultScheduler&) = default;
+  DefaultScheduler(DefaultScheduler&&) noexcept = default;
+
+  DefaultScheduler& operator=(const DefaultScheduler&) = default;
+  DefaultScheduler& operator=(DefaultScheduler&&) noexcept = default;
+
   ~DefaultScheduler() override = default;
 
   bool Continuable(const Context&) override {

--- a/eventuals/semaphore.h
+++ b/eventuals/semaphore.h
@@ -53,13 +53,15 @@ class Semaphore {
     semaphore = CHECK_NOTNULL(CreateSemaphore(nullptr, 0, LONG_MAX, nullptr));
   }
 
-  Semaphore(const Semaphore& other) = delete;
+  Semaphore(const Semaphore&) = delete;
+  Semaphore(Semaphore&&) = delete;
+
+  Semaphore& operator=(const Semaphore&) = delete;
+  Semaphore& operator=(Semaphore&&) noexcept = delete;
 
   ~Semaphore() {
     CHECK(CloseHandle(semaphore));
   }
-
-  Semaphore& operator=(const Semaphore& other) = delete;
 
   void Wait() {
     CHECK_EQ(WAIT_OBJECT_0, WaitForSingleObject(semaphore, INFINITE));

--- a/eventuals/stream.h
+++ b/eventuals/stream.h
@@ -162,7 +162,10 @@ struct _Stream final {
         stop_(std::move(stop)),
         k_(std::move(k)) {}
 
+    Continuation(const Continuation&) = delete;
     Continuation(Continuation&& that) noexcept = default;
+
+    Continuation& operator=(const Continuation&) = delete;
 
     Continuation& operator=(Continuation&& that) noexcept {
       if (this == &that) {

--- a/eventuals/take.h
+++ b/eventuals/take.h
@@ -21,7 +21,11 @@ struct _TakeLast final {
       : n_(n),
         k_(std::move(k)) {}
 
-    Continuation(Continuation&& that) noexcept = default;
+    Continuation(const Continuation&) = delete;
+    Continuation(Continuation&&) noexcept = default;
+
+    Continuation& operator=(const Continuation&) = delete;
+    Continuation& operator=(Continuation&&) noexcept = delete;
 
     ~Continuation() override = default;
 
@@ -148,7 +152,11 @@ struct _TakeRange final {
         amount_(amount),
         k_(std::move(k)) {}
 
-    Continuation(Continuation&& that) noexcept = default;
+    Continuation(const Continuation&) = delete;
+    Continuation(Continuation&&) noexcept = default;
+
+    Continuation& operator=(const Continuation&) = delete;
+    Continuation& operator=(Continuation&&) noexcept = delete;
 
     ~Continuation() override = default;
 

--- a/eventuals/task.h
+++ b/eventuals/task.h
@@ -521,10 +521,15 @@ class _Task final {
     CHECK(!that.k_.has_value()) << "moving after starting";
   }
 
+  _Task(const _Task&) = delete;
+
   _Task(_Task&& that) noexcept
     : e_(std::move(that.e_)) {
     CHECK(!that.k_.has_value()) << "moving after starting";
   }
+
+  _Task& operator=(const _Task&) = delete;
+  _Task& operator=(_Task&&) noexcept = delete;
 
   ~_Task() = default;
 

--- a/eventuals/terminal.h
+++ b/eventuals/terminal.h
@@ -175,8 +175,12 @@ struct _Terminal final {
 
 struct StoppedException final : public std::exception {
   StoppedException() = default;
-  StoppedException(const StoppedException& that) = default;
-  StoppedException(StoppedException&& that) = default;
+
+  StoppedException(const StoppedException&) = default;
+  StoppedException(StoppedException&&) = default;
+
+  StoppedException& operator=(const StoppedException&) = delete;
+  StoppedException& operator=(StoppedException&&) noexcept = delete;
 
   ~StoppedException() override = default;
 

--- a/eventuals/type-erased-stream.h
+++ b/eventuals/type-erased-stream.h
@@ -7,7 +7,16 @@ namespace eventuals {
 ////////////////////////////////////////////////////////////////////////
 
 struct TypeErasedStream {
+  TypeErasedStream() = default;
+
+  TypeErasedStream(const TypeErasedStream&) = default;
+  TypeErasedStream(TypeErasedStream&&) noexcept = default;
+
+  TypeErasedStream& operator=(const TypeErasedStream&) = default;
+  TypeErasedStream& operator=(TypeErasedStream&&) noexcept = default;
+
   virtual ~TypeErasedStream() = default;
+
   virtual void Next() = 0;
   virtual void Done() = 0;
 };

--- a/eventuals/x509.h
+++ b/eventuals/x509.h
@@ -57,6 +57,8 @@ class Certificate final {
     return *this;
   }
 
+  ~Certificate() = default;
+
   operator X509*() {
     return CHECK_NOTNULL(certificate_.get());
   }
@@ -96,6 +98,12 @@ template <
     bool has_organization_name_>
 class Certificate::_Builder final : public builder::Builder {
  public:
+  _Builder(const _Builder&) = default;
+  _Builder(_Builder&&) noexcept = default;
+
+  _Builder& operator=(const _Builder&) = default;
+  _Builder& operator=(_Builder&&) noexcept = default;
+
   ~_Builder() override = default;
 
   auto subject_key(rsa::Key&& subject_key) && {


### PR DESCRIPTION
To comply with the rule C.21 of C++ Core Guidelines:
https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#c21-if-you-define-or-delete-any-copy-move-or-destructor-function-define-or-delete-them-all

This *should* have the same behavior as our implicitly-generated version.