### PR TITLE
Avoid unecessary `auto`

### DIFF
--- a/eventuals/builder.h
+++ b/eventuals/builder.h
@@ -35,27 +35,27 @@ class Field<Value_, true> {
 
   virtual ~Field() = default;
 
-  auto& value() & {
+  Value_& value() & {
     return value_;
   }
 
-  const auto& value() const& {
+  const Value_& value() const& {
     return value_;
   }
 
-  auto&& value() && {
+  Value_&& value() && {
     return std::move(value_);
   }
 
-  const auto&& value() const&& {
+  const Value_&& value() const&& {
     return std::move(value_);
   }
 
-  const auto* operator->() const {
+  const Value_* operator->() const {
     return &value_;
   }
 
-  auto* operator->() {
+  Value_* operator->() {
     return &value_;
   }
 
@@ -87,27 +87,27 @@ class FieldWithDefault<Value_, false> final : public Field<Value_, false> {
     return FieldWithDefault<Value_, true>{Value_{std::forward<Args>(args)...}};
   }
 
-  auto& value() & {
+  Value_& value() & {
     return default_;
   }
 
-  const auto& value() const& {
+  const Value_& value() const& {
     return default_;
   }
 
-  auto&& value() && {
+  Value_&& value() && {
     return std::move(default_);
   }
 
-  const auto&& value() const&& {
+  const Value_&& value() const&& {
     return std::move(default_);
   }
 
-  const auto* operator->() const {
+  const Value_* operator->() const {
     return &default_;
   }
 
-  auto* operator->() {
+  Value_* operator->() {
     return &default_;
   }
 
@@ -153,27 +153,27 @@ class RepeatedField<Value_, false> final : public Field<Value_, false> {
     return RepeatedField<Value_, true>{Value_{std::forward<Args>(args)...}};
   }
 
-  auto& value() & {
+  Value_& value() & {
     return default_;
   }
 
-  const auto& value() const& {
+  const Value_& value() const& {
     return default_;
   }
 
-  auto&& value() && {
+  Value_&& value() && {
     return std::move(default_);
   }
 
-  const auto&& value() const&& {
+  const Value_&& value() const&& {
     return std::move(default_);
   }
 
-  const auto* operator->() const {
+  const Value_* operator->() const {
     return &default_;
   }
 
-  auto* operator->() {
+  Value_* operator->() {
     return &default_;
   }
 

--- a/eventuals/dns-resolver.h
+++ b/eventuals/dns-resolver.h
@@ -27,19 +27,19 @@ namespace eventuals {
       Eventual<std::string>()
           .raises<std::runtime_error>()
           .context(Data{loop, address, port})
-          .start([](auto& data, auto& k) {
+          .start([](Data& data, auto& k) {
             using K = std::decay_t<decltype(k)>;
 
             data.k = static_cast<void*>(&k);
             data.resolver.data = &data;
 
-            auto error = uv_getaddrinfo(
+            int error = uv_getaddrinfo(
                 data.loop,
                 &(data.resolver),
                 [](uv_getaddrinfo_t* request,
                    int status,
                    struct addrinfo* result) {
-                  auto& data = *static_cast<Data*>(request->data);
+                  Data& data = *static_cast<Data*>(request->data);
                   if (status < 0) {
                     static_cast<K*>(data.k)->Fail(
                         std::runtime_error(uv_err_name(status)));
@@ -47,7 +47,7 @@ namespace eventuals {
                     // Array "ip" is resulting IPv4 for the specified address.
                     char ip[17] = {'\0'};
 
-                    auto error = uv_ip4_name(
+                    int error = uv_ip4_name(
                         (struct sockaddr_in*) result->ai_addr,
                         ip,
                         16);

--- a/eventuals/event-loop.cc
+++ b/eventuals/event-loop.cc
@@ -46,7 +46,7 @@ void EventLoop::Clock::Resume() {
 
   std::scoped_lock lock(mutex_);
 
-  for (auto& pending : pending_) {
+  for (Pending& pending : pending_) {
     pending.callback(pending.nanoseconds - advanced_);
   }
 

--- a/eventuals/event-loop.h
+++ b/eventuals/event-loop.h
@@ -225,7 +225,7 @@ class EventLoop final : public Scheduler {
           // some later timer after a paused clock has been advanced
           // or unpaused.
           clock_->Submit(
-              this->Borrow([this](const auto& nanoseconds) {
+              this->Borrow([this](const std::chrono::nanoseconds& nanoseconds) {
                 // NOTE: need to update nanoseconds in the event the clock
                 // was paused/advanced and the nanosecond count differs.
                 nanoseconds_ = nanoseconds;
@@ -306,7 +306,7 @@ class EventLoop final : public Scheduler {
           loop().Submit(
               this->Borrow([tuple = std::move(tuple)]() mutable {
                 std::apply(
-                    [](auto* continuation, auto&&... args) {
+                    [](Continuation* continuation, auto&&... args) {
                       if (!continuation->completed_) {
                         CHECK(!continuation->started_);
                         continuation->completed_ = true;
@@ -1264,7 +1264,7 @@ template <typename E>
 ////////////////////////////////////////////////////////////////////////
 
 // Returns the default event loop's clock.
-[[nodiscard]] inline auto& Clock() {
+[[nodiscard]] inline EventLoop::Clock& Clock() {
   return EventLoop::Default().clock();
 }
 

--- a/eventuals/filesystem.h
+++ b/eventuals/filesystem.h
@@ -169,7 +169,7 @@ class File final {
       Eventual<File>()
           .raises<std::runtime_error>()
           .context(Data{loop, flags, mode, path})
-          .start([](auto& data, auto& k) mutable {
+          .start([](Data& data, auto& k) mutable {
             using K = std::decay_t<decltype(k)>;
 
             data.k = &k;
@@ -216,7 +216,7 @@ class File final {
       Eventual<void>()
           .raises<std::runtime_error>()
           .context(Data{loop, std::move(file)})
-          .start([](auto& data, auto& k) mutable {
+          .start([](Data& data, auto& k) mutable {
             using K = std::decay_t<decltype(k)>;
 
             data.k = &k;
@@ -267,7 +267,7 @@ class File final {
       Eventual<std::string>()
           .raises<std::runtime_error>()
           .context(Data{loop, file, bytes_to_read, offset, bytes_to_read})
-          .start([](auto& data, auto& k) mutable {
+          .start([](Data& data, auto& k) mutable {
             using K = std::decay_t<decltype(k)>;
 
             data.k = &k;
@@ -319,7 +319,7 @@ class File final {
       Eventual<void>()
           .raises<std::runtime_error>()
           .context(Data{loop, file, data, offset})
-          .start([](auto& data, auto& k) mutable {
+          .start([](Data& data, auto& k) mutable {
             using K = std::decay_t<decltype(k)>;
 
             data.k = &k;
@@ -367,7 +367,7 @@ class File final {
       Eventual<void>()
           .raises<std::runtime_error>()
           .context(Data{loop, path})
-          .start([](auto& data, auto& k) mutable {
+          .start([](Data& data, auto& k) mutable {
             using K = std::decay_t<decltype(k)>;
 
             data.k = &k;
@@ -414,7 +414,7 @@ class File final {
       Eventual<void>()
           .raises<std::runtime_error>()
           .context(Data{loop, path, mode})
-          .start([](auto& data, auto& k) mutable {
+          .start([](Data& data, auto& k) mutable {
             using K = std::decay_t<decltype(k)>;
 
             data.k = &k;
@@ -460,7 +460,7 @@ class File final {
       Eventual<void>()
           .raises<std::runtime_error>()
           .context(Data{loop, path})
-          .start([](auto& data, auto& k) mutable {
+          .start([](Data& data, auto& k) mutable {
             using K = std::decay_t<decltype(k)>;
 
             data.k = &k;
@@ -509,7 +509,7 @@ class File final {
       Eventual<void>()
           .raises<std::runtime_error>()
           .context(Data{loop, src, dst, flags})
-          .start([](auto& data, auto& k) mutable {
+          .start([](Data& data, auto& k) mutable {
             using K = std::decay_t<decltype(k)>;
 
             data.k = &k;
@@ -558,7 +558,7 @@ class File final {
       Eventual<void>()
           .raises<std::runtime_error>()
           .context(Data{loop, src, dst})
-          .start([](auto& data, auto& k) mutable {
+          .start([](Data& data, auto& k) mutable {
             using K = std::decay_t<decltype(k)>;
 
             data.k = &k;

--- a/eventuals/grpc/client.h
+++ b/eventuals/grpc/client.h
@@ -200,15 +200,15 @@ class ClientCall {
       reader_(path_, host_, context_, stream_.get()),
       writer_(path_, host_, context_, stream_.get()) {}
 
-  auto* context() {
+  ::grpc::ClientContext* context() {
     return context_;
   }
 
-  auto& Reader() {
+  ClientReader<ResponseType_>& Reader() {
     return reader_;
   }
 
-  auto& Writer() {
+  ClientWriter<RequestType_>& Writer() {
     return writer_;
   }
 

--- a/eventuals/grpc/server.h
+++ b/eventuals/grpc/server.h
@@ -382,11 +382,11 @@ class ServerCall {
     return context_->context();
   }
 
-  auto& Reader() {
+  ServerReader<RequestType_>& Reader() {
     return reader_;
   }
 
-  auto& Writer() {
+  ServerWriter<ResponseType_>& Writer() {
     return writer_;
   }
 

--- a/eventuals/iterate.h
+++ b/eventuals/iterate.h
@@ -45,18 +45,18 @@ template <typename Container>
 
   return Stream<T>()
       .context(Data{container, std::nullopt})
-      .begin([](auto& data, auto& k) {
+      .begin([](Data& data, auto& k) {
         data.begin = data.container.cbegin();
         k.Begin();
       })
-      .next([](auto& data, auto& k) {
+      .next([](Data& data, auto& k) {
         if (data.begin.value() != data.container.cend()) {
           k.Emit(*(data.begin.value()++));
         } else {
           k.Ended();
         }
       })
-      .done([](auto&, auto& k) {
+      .done([](Data&, auto& k) {
         k.Ended();
       });
 }
@@ -76,18 +76,18 @@ template <typename Container>
 
   return Stream<T>()
       .context(Data{container, std::nullopt})
-      .begin([](auto& data, auto& k) {
+      .begin([](Data& data, auto& k) {
         data.begin = data.container.begin();
         k.Begin();
       })
-      .next([](auto& data, auto& k) {
+      .next([](Data& data, auto& k) {
         if (data.begin.value() != data.container.end()) {
           k.Emit(*(data.begin.value()++));
         } else {
           k.Ended();
         }
       })
-      .done([](auto&, auto& k) {
+      .done([](Data&, auto& k) {
         k.Ended();
       });
 }
@@ -109,18 +109,18 @@ template <typename Container>
 
   return Stream<T>()
       .context(Data{std::move(container), std::nullopt})
-      .begin([](auto& data, auto& k) {
+      .begin([](Data& data, auto& k) {
         data.begin = data.container.begin();
         k.Begin();
       })
-      .next([](auto& data, auto& k) {
+      .next([](Data& data, auto& k) {
         if (data.begin.value() != data.container.end()) {
           k.Emit(std::move(*(data.begin.value()++)));
         } else {
           k.Ended();
         }
       })
-      .done([](auto&, auto& k) {
+      .done([](Data&, auto& k) {
         k.Ended();
       });
 }

--- a/eventuals/pipe.h
+++ b/eventuals/pipe.h
@@ -43,7 +43,7 @@ class Pipe final : public Synchronizable {
                })
                >> Map([this]() {
                    if (!values_.empty()) {
-                     auto value = std::move(values_.front());
+                     T value = std::move(values_.front());
                      values_.pop_front();
                      return std::make_optional(std::move(value));
                    } else {
@@ -51,10 +51,10 @@ class Pipe final : public Synchronizable {
                      return std::optional<T>();
                    }
                  }))
-        >> Until([](auto& value) {
+        >> Until([](std::optional<T>& value) {
              return !value.has_value();
            })
-        >> Map([](auto&& value) {
+        >> Map([](std::optional<T>&& value) {
              CHECK(value);
              // NOTE: need to use 'Just' here in case 'T' is an
              // eventual otherwise we'll try and compose with it here!

--- a/eventuals/static-thread-pool.cc
+++ b/eventuals/static-thread-pool.cc
@@ -107,10 +107,10 @@ StaticThreadPool::StaticThreadPool()
 StaticThreadPool::~StaticThreadPool() {
   shutdown_.store(true);
   while (!threads_.empty()) {
-    auto* semaphore = semaphores_.back();
+    Semaphore* semaphore = semaphores_.back();
     semaphore->Signal();
     semaphores_.pop_back();
-    auto& thread = threads_.back();
+    std::thread& thread = threads_.back();
     thread.join();
     threads_.pop_back();
   }
@@ -128,7 +128,7 @@ void StaticThreadPool::Submit(Callback<void()> callback, Context& context) {
   auto* requirements =
       static_cast<StaticThreadPool::Requirements*>(context.data);
 
-  auto& pinned = requirements->pinned;
+  Pinned& pinned = requirements->pinned;
 
   CHECK(pinned.cpu()) << context.name();
 
@@ -173,7 +173,7 @@ bool StaticThreadPool::Continuable(const Context& context) {
   auto* requirements =
       static_cast<StaticThreadPool::Requirements*>(context.data);
 
-  auto& pinned = requirements->pinned;
+  Pinned& pinned = requirements->pinned;
 
   CHECK(pinned.cpu()) << context.name();
 

--- a/eventuals/static-thread-pool.h
+++ b/eventuals/static-thread-pool.h
@@ -177,7 +177,7 @@ struct _StaticThreadPoolSchedule final {
 
       EVENTUALS_LOG(1) << "Scheduling '" << context_->name() << "'";
 
-      auto& pinned = requirements()->pinned;
+      Pinned& pinned = requirements()->pinned;
 
       if (!pinned.cpu()) {
         // TODO(benh): pick the least loaded cpu. This will require
@@ -225,7 +225,7 @@ struct _StaticThreadPoolSchedule final {
 
       EVENTUALS_LOG(1) << "Scheduling '" << context_->name() << "'";
 
-      auto& pinned = requirements()->pinned;
+      Pinned& pinned = requirements()->pinned;
 
       if (!pinned.cpu()) {
         // TODO(benh): pick the least loaded cpu. This will require
@@ -276,7 +276,7 @@ struct _StaticThreadPoolSchedule final {
 
       EVENTUALS_LOG(1) << "Scheduling '" << context_->name() << "'";
 
-      auto& pinned = requirements()->pinned;
+      Pinned& pinned = requirements()->pinned;
 
       if (!pinned.cpu()) {
         // TODO(benh): pick the least loaded cpu. This will require
@@ -313,7 +313,7 @@ struct _StaticThreadPoolSchedule final {
 
       EVENTUALS_LOG(1) << "Scheduling '" << context_->name() << "'";
 
-      auto& pinned = requirements()->pinned;
+      Pinned& pinned = requirements()->pinned;
 
       if (!pinned.cpu()) {
         // TODO(benh): pick the least loaded cpu. This will require
@@ -352,7 +352,7 @@ struct _StaticThreadPoolSchedule final {
 
       EVENTUALS_LOG(1) << "Scheduling '" << context_->name() << "'";
 
-      auto& pinned = requirements()->pinned;
+      Pinned& pinned = requirements()->pinned;
 
       if (!pinned.cpu()) {
         // TODO(benh): pick the least loaded cpu. This will require
@@ -399,7 +399,7 @@ struct _StaticThreadPoolSchedule final {
 
       EVENTUALS_LOG(1) << "Scheduling '" << context_->name() << "'";
 
-      auto& pinned = requirements()->pinned;
+      Pinned& pinned = requirements()->pinned;
 
       if (!pinned.cpu()) {
         // TODO(benh): pick the least loaded cpu. This will require

--- a/protoc-gen-eventuals/templates/eventuals.cc.j2
+++ b/protoc-gen-eventuals/templates/eventuals.cc.j2
@@ -53,7 +53,7 @@ Task::Of<void> {{ service.name }}::TypeErasedService::Serve{{ method.name }}() {
 {%- if not method.server_streaming and not method.client_streaming %}
 {#- No streaming #}
                 return UnaryPrologue(call)
-                    >> Then(Let([&](auto& request) {
+                    >> Then(Let([&]({{ input_type }}& request) {
                         return Then(
                             [&,
                               // NOTE: using a tuple because need
@@ -88,7 +88,7 @@ Task::Of<void> {{ service.name }}::TypeErasedService::Serve{{ method.name }}() {
 {%- elif method.server_streaming and not method.client_streaming %}
 {#- Server streaming #}
                 return UnaryPrologue(call)
-                    >> Then(Let([&](auto& request) {
+                    >> Then(Let([&]({{ input_type }}& request) {
                         return Then(
                             [&,
                               // NOTE: using a tuple because need

--- a/test/catch.cc
+++ b/test/catch.cc
@@ -23,13 +23,13 @@ TEST(CatchTest, RaisedRuntimeError) {
     return Just(1)
         >> Raise(std::runtime_error("message"))
         >> Catch()
-               .raised<std::overflow_error>([](auto&& error) {
+               .raised<std::overflow_error>([](std::overflow_error&& error) {
                  ADD_FAILURE() << "Encountered unexpected matched raised";
                  return Then([]() {
                    return 100;
                  });
                })
-               .raised<std::runtime_error>([](auto&& error) {
+               .raised<std::runtime_error>([](std::runtime_error&& error) {
                  EXPECT_STREQ(error.what(), "message");
                  return Just(100);
                });
@@ -54,12 +54,12 @@ TEST(CatchTest, ChildException) {
     return Just(1)
         >> Raise(Error{})
         >> Catch()
-               .raised<std::overflow_error>([](auto&& error) {
+               .raised<std::overflow_error>([](std::overflow_error&& error) {
                  ADD_FAILURE() << "Encountered unexpected matched raised";
                  return Just(10);
                })
                .raised<std::exception>(
-                   [](auto&& error) {
+                   [](std::exception&& error) {
                      EXPECT_STREQ("child exception", error.what());
                      return Just(100);
                    });
@@ -78,11 +78,11 @@ TEST(CatchTest, All) {
     return Just(500)
         >> Raise(std::runtime_error("10"))
         >> Catch()
-               .raised<std::overflow_error>([](auto&& error) {
+               .raised<std::overflow_error>([](std::overflow_error&& error) {
                  ADD_FAILURE() << "Encountered unexpected matched raised";
                  return 10;
                })
-               .raised<std::underflow_error>([](auto&& error) {
+               .raised<std::underflow_error>([](std::underflow_error&& error) {
                  ADD_FAILURE() << "Encountered unexpected matched raised";
                  return 10;
                })
@@ -121,13 +121,13 @@ TEST(CatchTest, UnexpectedRaise) {
   auto e = [&]() {
     return f() // Throwing 'std::exception_ptr' there.
         >> Catch()
-               .raised<std::overflow_error>([](auto&& error) {
+               .raised<std::overflow_error>([](std::overflow_error&& error) {
                  ADD_FAILURE() << "Encountered unexpected matched raised";
                  return 1;
                })
                // Receive 'Error' type there, that had been rethrowed from
                // 'std::exception_ptr'.
-               .raised<Error>([](auto&& error) {
+               .raised<Error>([](Error&& error) {
                  EXPECT_STREQ("child exception", error.what());
                  return 100;
                });
@@ -155,11 +155,11 @@ TEST(CatchTest, UnexpectedAll) {
   auto e = [&]() {
     return f() // Throwing 'std::exception_ptr' there.
         >> Catch()
-               .raised<std::overflow_error>([](auto&& error) {
+               .raised<std::overflow_error>([](std::overflow_error&& error) {
                  ADD_FAILURE() << "Encountered unexpected matched raised";
                  return 1;
                })
-               .raised<std::underflow_error>([](auto&& error) {
+               .raised<std::underflow_error>([](std::underflow_error&& error) {
                  ADD_FAILURE() << "Encountered unexpected matched raised";
                  return 1;
                })
@@ -189,11 +189,11 @@ TEST(CatchTest, NoExactHandler) {
     return Just(1)
         >> Raise(std::string("error"))
         >> Catch()
-               .raised<std::overflow_error>([](auto&& error) {
+               .raised<std::overflow_error>([](std::overflow_error&& error) {
                  ADD_FAILURE() << "Encountered unexpected matched raised";
                  return 1;
                })
-               .raised<std::underflow_error>([](auto&& error) {
+               .raised<std::underflow_error>([](std::underflow_error&& error) {
                  ADD_FAILURE() << "Encountered unexpected matched raised";
                  return 1;
                });
@@ -212,7 +212,7 @@ TEST(CatchTest, ReRaise) {
     return Just(1)
         >> Raise("10")
         >> Catch()
-               .raised<std::runtime_error>([](auto&& error) {
+               .raised<std::runtime_error>([](std::runtime_error&& error) {
                  EXPECT_STREQ(error.what(), "10");
                  return Raise("1");
                })
@@ -220,15 +220,15 @@ TEST(CatchTest, ReRaise) {
                  ADD_FAILURE() << "Encountered an unexpected all";
                  return Just(100);
                })
-        >> Then([](auto&&) {
+        >> Then([](int&&) {
              return 200;
            })
         >> Catch()
-               .raised<std::runtime_error>([](auto&& error) {
+               .raised<std::runtime_error>([](std::runtime_error&& error) {
                  EXPECT_STREQ(error.what(), "1");
                  return Just(10);
                })
-        >> Then([](auto value) {
+        >> Then([](int value) {
              return value;
            });
   };
@@ -248,7 +248,7 @@ TEST(CatchTest, VoidPropagate) {
              return;
            })
         >> Catch()
-               .raised<std::exception>([](auto&& error) {
+               .raised<std::exception>([](std::exception&& error) {
                  EXPECT_STREQ(error.what(), "error");
                  // MUST RETURN VOID HERE!
                })
@@ -270,13 +270,13 @@ TEST(CatchTest, Interrupt) {
     return Just(1)
         >> Raise(std::runtime_error("message"))
         >> Catch()
-               .raised<std::overflow_error>([](auto&& error) {
+               .raised<std::overflow_error>([](std::overflow_error&& error) {
                  ADD_FAILURE() << "Encountered unexpected matched raised";
                  return Then([]() {
                    return 100;
                  });
                })
-               .raised<std::runtime_error>([](auto&& error) {
+               .raised<std::runtime_error>([](std::runtime_error&& error) {
                  EXPECT_STREQ(error.what(), "message");
                  return Just(100);
                })

--- a/test/closure.cc
+++ b/test/closure.cc
@@ -30,7 +30,7 @@ TEST(ClosureTest, Then) {
   auto e = []() {
     return Just(1)
         >> Closure([i = 41]() {
-             return Then([&](auto&& value) { return i + value; });
+             return Then([&](int&& value) { return i + value; });
            });
   };
 
@@ -41,7 +41,7 @@ TEST(ClosureTest, Then) {
 TEST(ClosureTest, Functor) {
   struct Functor {
     auto operator()() {
-      return Then([this](auto&& value) { return i + value; });
+      return Then([this](int&& value) { return i + value; });
     }
 
     int i;
@@ -62,8 +62,8 @@ TEST(ClosureTest, OuterRepeat) {
         >> Closure([i = 41]() {
              return Reduce(
                  i,
-                 [](auto& i) {
-                   return Then([&](auto&& value) {
+                 [](int& i) {
+                   return Then([&](int&& value) {
                      i += value;
                      return false;
                    });
@@ -83,14 +83,14 @@ TEST(ClosureTest, InnerRepeat) {
                return strings.empty();
              })
           >> Map([&]() mutable {
-               auto s = std::move(strings.front());
+               string s = std::move(strings.front());
                strings.pop_front();
                return s;
              })
           >> Reduce(
                  deque<string>(),
-                 [](auto& results) {
-                   return Then([&](auto&& result) mutable {
+                 [](deque<string>& results) {
+                   return Then([&](string&& result) mutable {
                      results.push_back(result);
                      return true;
                    });
@@ -98,7 +98,7 @@ TEST(ClosureTest, InnerRepeat) {
     });
   };
 
-  auto results = *e();
+  deque<string> results = *e();
 
   EXPECT_THAT(results, ElementsAre("hello", "world"));
 }

--- a/test/concurrent/downstream-done-both-eventuals-success.cc
+++ b/test/concurrent/downstream-done-both-eventuals-success.cc
@@ -40,8 +40,8 @@ TYPED_TEST(ConcurrentTypedTest, DownstreamDoneBothEventualsSuccess) {
           })
         >> Reduce(
                std::string(),
-               [](auto& result) {
-                 return Then([&](auto&& value) {
+               [](std::string& result) {
+                 return Then([&](std::string&& value) {
                    result = value;
                    return false; // Only take the first element!
                  });
@@ -63,7 +63,7 @@ TYPED_TEST(ConcurrentTypedTest, DownstreamDoneBothEventualsSuccess) {
       std::future_status::timeout,
       future.wait_for(std::chrono::seconds(0)));
 
-  for (auto& callback : callbacks) {
+  for (Callback<void()>& callback : callbacks) {
     callback();
   }
 

--- a/test/concurrent/downstream-done-one-eventual-fail.cc
+++ b/test/concurrent/downstream-done-one-eventual-fail.cc
@@ -44,8 +44,8 @@ TYPED_TEST(ConcurrentTypedTest, DownstreamDoneOneEventualFail) {
           })
         >> Reduce(
                std::string(),
-               [](auto& result) {
-                 return Then([&](auto&& value) {
+               [](std::string& result) {
+                 return Then([&](std::string&& value) {
                    result = value;
                    return false; // Only take the first element!
                  });
@@ -67,7 +67,7 @@ TYPED_TEST(ConcurrentTypedTest, DownstreamDoneOneEventualFail) {
       std::future_status::timeout,
       future.wait_for(std::chrono::seconds(0)));
 
-  for (auto& callback : callbacks) {
+  for (Callback<void()>& callback : callbacks) {
     callback();
   }
 

--- a/test/concurrent/downstream-done-one-eventual-stop.cc
+++ b/test/concurrent/downstream-done-one-eventual-stop.cc
@@ -43,8 +43,8 @@ TYPED_TEST(ConcurrentTypedTest, DownstreamDoneOneEventualStop) {
           })
         >> Reduce(
                std::string(),
-               [](auto& result) {
-                 return Then([&](auto&& value) {
+               [](std::string& result) {
+                 return Then([&](std::string&& value) {
                    result = value;
                    return false; // Only take the first element!
                  });
@@ -66,7 +66,7 @@ TYPED_TEST(ConcurrentTypedTest, DownstreamDoneOneEventualStop) {
       std::future_status::timeout,
       future.wait_for(std::chrono::seconds(0)));
 
-  for (auto& callback : callbacks) {
+  for (Callback<void()>& callback : callbacks) {
     callback();
   }
 

--- a/test/concurrent/fail-or-stop.cc
+++ b/test/concurrent/fail-or-stop.cc
@@ -62,7 +62,7 @@ TYPED_TEST(ConcurrentTypedTest, FailOrStop) {
       std::future_status::timeout,
       future.wait_for(std::chrono::seconds(0)));
 
-  for (auto& callback : callbacks) {
+  for (Callback<void()>& callback : callbacks) {
     callback();
   }
 

--- a/test/concurrent/fail.cc
+++ b/test/concurrent/fail.cc
@@ -65,7 +65,7 @@ TYPED_TEST(ConcurrentTypedTest, Fail) {
       std::future_status::timeout,
       future.wait_for(std::chrono::seconds(0)));
 
-  for (auto& callback : callbacks) {
+  for (Callback<void()>& callback : callbacks) {
     callback();
   }
 

--- a/test/concurrent/interrupt-success.cc
+++ b/test/concurrent/interrupt-success.cc
@@ -68,7 +68,7 @@ TYPED_TEST(ConcurrentTypedTest, InterruptSuccess) {
       std::future_status::timeout,
       future.wait_for(std::chrono::seconds(0)));
 
-  for (auto& callback : callbacks) {
+  for (Callback<void()>& callback : callbacks) {
     callback();
   }
 

--- a/test/concurrent/moveable.cc
+++ b/test/concurrent/moveable.cc
@@ -22,7 +22,7 @@ TYPED_TEST(ConcurrentTypedTest, Moveable) {
   auto e = [&]() {
     return Iterate({Moveable()})
         >> this->ConcurrentOrConcurrentOrdered([]() {
-            return Map(Let([](auto& moveable) {
+            return Map(Let([](Moveable& moveable) {
               return 42;
             }));
           })

--- a/test/concurrent/stop.cc
+++ b/test/concurrent/stop.cc
@@ -59,7 +59,7 @@ TYPED_TEST(ConcurrentTypedTest, Stop) {
       std::future_status::timeout,
       future.wait_for(std::chrono::seconds(0)));
 
-  for (auto& callback : callbacks) {
+  for (Callback<void()>& callback : callbacks) {
     callback();
   }
 

--- a/test/concurrent/success.cc
+++ b/test/concurrent/success.cc
@@ -55,7 +55,7 @@ TYPED_TEST(ConcurrentTypedTest, Success) {
       std::future_status::timeout,
       future.wait_for(std::chrono::seconds(0)));
 
-  for (auto& callback : callbacks) {
+  for (Callback<void()>& callback : callbacks) {
     callback();
   }
 

--- a/test/conditional.cc
+++ b/test/conditional.cc
@@ -37,9 +37,9 @@ TEST(ConditionalTest, Then) {
     return Just(1)
         >> Then([](int i) { return i + 1; })
         >> Conditional(
-               [](auto&& i) { return i > 1; },
-               [&](auto&&) { return then(); },
-               [&](auto&&) { return els3(); });
+               [](int&& i) { return i > 1; },
+               [&](int&&) { return then(); },
+               [&](int&&) { return els3(); });
   };
 
   EXPECT_EQ("then", *c());
@@ -65,9 +65,9 @@ TEST(ConditionalTest, Else) {
     return Just(0)
         >> Then([](int i) { return i + 1; })
         >> Conditional(
-               [](auto&& i) { return i > 1; },
-               [&](auto&&) { return then(); },
-               [&](auto&&) { return els3(); });
+               [](int&& i) { return i > 1; },
+               [&](int&&) { return then(); },
+               [&](int&&) { return els3(); });
   };
 
   EXPECT_EQ("else", *c());
@@ -101,9 +101,9 @@ TEST(ConditionalTest, Fail) {
                })
         >> Then([](int i) { return i + 1; })
         >> Conditional(
-               [](auto&& i) { return i > 1; },
-               [&](auto&&) { return then(); },
-               [&](auto&&) { return els3(); });
+               [](int&& i) { return i > 1; },
+               [&](int&&) { return then(); },
+               [&](int&&) { return els3(); });
   };
 
   static_assert(
@@ -144,9 +144,9 @@ TEST(ConditionalTest, Interrupt) {
     return Just(1)
         >> Then([](int i) { return i + 1; })
         >> Conditional(
-               [](auto&& i) { return i > 1; },
-               [&](auto&&) { return then(); },
-               [&](auto&&) { return els3(); });
+               [](int&& i) { return i > 1; },
+               [&](int&&) { return then(); },
+               [&](int&&) { return els3(); });
   };
 
   auto [future, k] = PromisifyForTest(c());
@@ -171,9 +171,9 @@ TEST(ConditionalTest, Raise) {
     return Just(1)
         >> Then([](int i) { return i + 1; })
         >> Conditional(
-               [](auto&& i) { return i > 1; },
-               [](auto&& i) { return Just(i); },
-               [](auto&& i) { return Raise("raise"); });
+               [](int&& i) { return i > 1; },
+               [](int&& i) { return Just(i); },
+               [](int&& i) { return Raise("raise"); });
   };
 
   static_assert(

--- a/test/dns-resolver.cc
+++ b/test/dns-resolver.cc
@@ -56,7 +56,7 @@ TEST_F(DomainNameResolveTest, Stop) {
   std::string address = "localhost", port = "6667";
   auto e = DomainNameResolve(address, port)
       >> Eventual<int>()
-             .start([](auto& k, auto&& ip) {
+             .start([](auto& k, std::string&& ip) {
                // Imagine that we got ip, and we try to connect
                // in order to get some data (int) from db for example,
                // but there was an error and we stop our continuation.
@@ -78,7 +78,7 @@ TEST_F(DomainNameResolveTest, Raises) {
   auto e = DomainNameResolve(address, port)
       >> Eventual<int>()
              .raises<std::overflow_error>()
-             .start([](auto& k, auto&& ip) {
+             .start([](auto& k, std::string&& ip) {
                // Imagine that we got ip, and we try to connect
                // in order to get some data (int) from db for example,
                // but there was an error and we stop our continuation.

--- a/test/filesystem.cc
+++ b/test/filesystem.cc
@@ -29,7 +29,7 @@ TEST_F(FilesystemTest, OpenAndCloseFileSucceed) {
 
   auto e = [&path]() {
     return OpenFile(path, UV_FS_O_RDONLY, 0)
-        >> Then([&path](auto&& file) {
+        >> Then([&path](File&& file) {
              return Closure([&path, file = std::move(file)]() mutable {
                EXPECT_TRUE(file.IsOpen());
                EXPECT_TRUE(std::filesystem::exists(path));
@@ -81,7 +81,7 @@ TEST_F(FilesystemTest, ReadFileSucceed) {
         >> Then([&](File&& file) {
              return Closure([&, file = std::move(file)]() mutable {
                return ReadFile(file, test_string.size(), 0)
-                   >> Then([&](auto&& data) {
+                   >> Then([&](std::string&& data) {
                         EXPECT_EQ(test_string, data);
                         return CloseFile(std::move(file));
                       })
@@ -114,7 +114,7 @@ TEST_F(FilesystemTest, ReadFileFail) {
         >> Then([&](File&& file) {
              return Closure([&, file = std::move(file)]() mutable {
                return ReadFile(file, test_string.size(), 0)
-                   >> Then([&](auto&& data) {
+                   >> Then([&](std::string&& data) {
                         EXPECT_EQ(test_string, data);
                         return CloseFile(std::move(file));
                       });

--- a/test/filter.cc
+++ b/test/filter.cc
@@ -67,11 +67,11 @@ TEST(Filter, OddMapLoopFlow) {
         >> Map([](int x) { return x + 1; })
         >> Loop<int>()
                .context(0)
-               .body([](auto& sum, auto& stream, auto&& value) {
+               .body([](int& sum, auto& stream, int&& value) {
                  sum += value;
                  stream.Next();
                })
-               .ended([](auto& sum, auto& k) {
+               .ended([](int& sum, auto& k) {
                  k.Start(sum);
                });
   };

--- a/test/finally.cc
+++ b/test/finally.cc
@@ -21,7 +21,7 @@ using testing::ThrowsMessage;
 TEST(Finally, Succeed) {
   auto e = []() {
     return Just(42)
-        >> Finally([](auto&& expected) {
+        >> Finally([](expected<int, std::exception_ptr>&& expected) {
              return Just(std::move(expected));
            });
   };
@@ -37,7 +37,7 @@ TEST(Finally, Fail) {
   auto e = []() {
     return Just(42)
         >> Raise("error")
-        >> Finally([](auto&& expected) {
+        >> Finally([](expected<int, std::exception_ptr>&& expected) {
              return Just(std::move(expected));
            });
   };
@@ -56,7 +56,7 @@ TEST(Finally, Stop) {
     return Eventual<std::string>([](auto& k) {
              k.Stop();
            })
-        >> Finally([](auto&& expected) {
+        >> Finally([](expected<std::string, std::exception_ptr>&& expected) {
              return Just(std::move(expected));
            });
   };
@@ -73,8 +73,8 @@ TEST(Finally, Stop) {
 TEST(Finally, VoidSucceed) {
   auto e = []() {
     return Just()
-        >> Finally([](auto&& exception) {
-             return Just(std::move(exception));
+        >> Finally([](expected<void, std::exception_ptr>&& expected) {
+             return Just(std::move(expected));
            });
   };
 
@@ -87,7 +87,7 @@ TEST(Finally, VoidFail) {
   auto e = []() {
     return Just()
         >> Raise("error")
-        >> Finally([](auto&& exception) {
+        >> Finally([](expected<void, std::exception_ptr>&& exception) {
              return Just(std::move(exception));
            });
   };
@@ -106,7 +106,7 @@ TEST(Finally, VoidStop) {
     return Eventual<void>([](auto& k) {
              k.Stop();
            })
-        >> Finally([](auto&& exception) {
+        >> Finally([](expected<void, std::exception_ptr>&& exception) {
              return Just(std::move(exception));
            });
   };

--- a/test/flat-map.cc
+++ b/test/flat-map.cc
@@ -198,7 +198,7 @@ TEST_F(FlatMapTest, Interrupt) {
            })
         >> FlatMap([](int x) { return Iterate({1, 2}); })
         >> Collect<std::vector<int>>()
-               .stop([](auto& collection, auto& k) {
+               .stop([](std::vector<int>& collection, auto& k) {
                  k.Start(std::move(collection));
                });
   };

--- a/test/generator.cc
+++ b/test/generator.cc
@@ -94,7 +94,7 @@ TEST(Generator, GeneratorWithNonCopyable) {
   auto generator = []() {
     return Generator::Of<int>::With<NonCopyable>(
         NonCopyable{100},
-        [](auto& non_copyable) {
+        [](NonCopyable& non_copyable) {
           return Iterate({non_copyable.x});
         });
   };

--- a/test/grpc/cancelled-by-client.cc
+++ b/test/grpc/cancelled-by-client.cc
@@ -38,7 +38,7 @@ TEST(CancelledByClientTest, Cancelled) {
   auto serve = [&]() {
     return server->Accept<Greeter, HelloRequest, HelloReply>("SayHello")
         >> Head()
-        >> Then(Let([](auto& call) {
+        >> Then(Let([](ServerCall<HelloRequest, HelloReply>& call) {
              return call.WaitForDone();
            }));
   };
@@ -56,7 +56,7 @@ TEST(CancelledByClientTest, Cancelled) {
 
   auto call = [&]() {
     return client.Call<Greeter, HelloRequest, HelloReply>("SayHello")
-        >> Then(Let([&](auto& call) {
+        >> Then(Let([&](ClientCall<HelloRequest, HelloReply>& call) {
              call.context()->TryCancel();
              return call.Finish();
            }));

--- a/test/grpc/cancelled-by-server.cc
+++ b/test/grpc/cancelled-by-server.cc
@@ -38,7 +38,7 @@ TEST(CancelledByServerTest, Cancelled) {
   auto serve = [&]() {
     return server->Accept<Greeter, HelloRequest, HelloReply>("SayHello")
         >> Head()
-        >> Then(Let([](auto& call) {
+        >> Then(Let([](ServerCall<HelloRequest, HelloReply>& call) {
              call.context()->TryCancel();
              return call.WaitForDone();
            }));
@@ -59,7 +59,7 @@ TEST(CancelledByServerTest, Cancelled) {
 
   auto call = [&]() {
     return client.Call<Greeter, HelloRequest, HelloReply>("SayHello", &context)
-        >> Then(Let([](auto& call) {
+        >> Then(Let([](ClientCall<HelloRequest, HelloReply>& call) {
              return call.WritesDone()
                  >> call.Finish();
            }));

--- a/test/grpc/client-death-test.cc
+++ b/test/grpc/client-death-test.cc
@@ -43,7 +43,7 @@ TEST(ClientDeathTest, ServerHandlesClientDisconnect) {
   auto serve = [&]() {
     return server->Accept<Greeter, HelloRequest, HelloReply>("SayHello")
         >> Head()
-        >> Then(Let([](auto& call) {
+        >> Then(Let([](ServerCall<HelloRequest, HelloReply>& call) {
              return call.WaitForDone();
            }));
   };

--- a/test/grpc/deadline.cc
+++ b/test/grpc/deadline.cc
@@ -39,7 +39,7 @@ TEST(DeadlineTest, DeadlineExceeded) {
   auto serve = [&]() {
     return server->Accept<Greeter, HelloRequest, HelloReply>("SayHello")
         >> Head()
-        >> Then(Let([](auto& call) {
+        >> Then(Let([](ServerCall<HelloRequest, HelloReply>& call) {
              return call.WaitForDone();
            }));
   };
@@ -64,7 +64,7 @@ TEST(DeadlineTest, DeadlineExceeded) {
              return client.Call<Greeter, HelloRequest, HelloReply>(
                         "SayHello",
                         context)
-                 >> Then(Let([](auto& call) {
+                 >> Then(Let([](ClientCall<HelloRequest, HelloReply>& call) {
                       HelloRequest request;
                       request.set_name("emily");
                       return call.Writer().WriteLast(request)

--- a/test/grpc/death-client.cc
+++ b/test/grpc/death-client.cc
@@ -23,7 +23,7 @@ void RunClient(const int port) {
 
   auto call = [&]() {
     return client.Call<Greeter, HelloRequest, HelloReply>("SayHello")
-        >> Then([](auto&& call) {
+        >> Then([](ClientCall<HelloRequest, HelloReply>&& call) {
              // NOTE: need to use 'std::_Exit()' to avoid deadlock
              // waiting for borrowed contexts to get relinquished.
              std::_Exit(kProcessIntentionalExitCode);

--- a/test/grpc/death-server.cc
+++ b/test/grpc/death-server.cc
@@ -37,7 +37,7 @@ void RunServer(const int pipe) {
   auto serve = [&]() {
     return server->Accept<Greeter, HelloRequest, HelloReply>("SayHello")
         >> Head()
-        >> Then([](auto&& call) {
+        >> Then([](ServerCall<HelloRequest, HelloReply>&& call) {
              // NOTE: need to use 'std::_Exit()' to avoid deadlock
              // waiting for borrowed contexts to get relinquished.
              std::_Exit(kProcessIntentionalExitCode);

--- a/test/grpc/greeter-server.cc
+++ b/test/grpc/greeter-server.cc
@@ -60,12 +60,12 @@ TEST(GreeterServerTest, SayHello) {
 
   auto call = [&]() {
     return client.Call<Greeter, HelloRequest, HelloReply>("SayHello")
-        >> Then(Let([](auto& call) {
+        >> Then(Let([](ClientCall<HelloRequest, HelloReply>& call) {
              HelloRequest request;
              request.set_name("emily");
              return call.Writer().WriteLast(request)
                  >> call.Reader().Read()
-                 >> Map([](auto&& response) {
+                 >> Map([](HelloReply&& response) {
                       EXPECT_EQ("Hello emily", response.message());
                     })
                  >> Loop()

--- a/test/grpc/helloworld.eventuals.cc
+++ b/test/grpc/helloworld.eventuals.cc
@@ -36,9 +36,12 @@ Task::Of<void> Greeter::TypeErasedService::Serve() {
                        helloworld::HelloRequest,
                        helloworld::HelloReply>("SayHello")
                >> Concurrent([this]() {
-                   return Map(Let([this](auto& call) {
+                   return Map(Let([this](
+                                      ::eventuals::grpc::ServerCall<
+                                          HelloRequest,
+                                          HelloReply>& call) {
                      return UnaryPrologue(call)
-                         >> Then(Let([&](auto& request) {
+                         >> Then(Let([&](HelloRequest& request) {
                               return Then(
                                   [&,
                                    // NOTE: using a tuple because need

--- a/test/grpc/multiple-hosts.cc
+++ b/test/grpc/multiple-hosts.cc
@@ -38,10 +38,10 @@ TEST(MultipleHostsTest, Success) {
   auto serve = [&](auto&& host) {
     return server->Accept<Greeter, HelloRequest, HelloReply>("SayHello", host)
         >> Head()
-        >> Then(Let([](auto& call) {
+        >> Then(Let([](ServerCall<HelloRequest, HelloReply>& call) {
              return call.Reader().Read()
                  >> Head() // Only get the first element.
-                 >> Then([](auto&& request) {
+                 >> Then([](HelloRequest&& request) {
                       HelloReply reply;
                       std::string prefix("Hello ");
                       reply.set_message(prefix + request.name());
@@ -68,7 +68,7 @@ TEST(MultipleHostsTest, Success) {
 
   auto call = [&](auto&& host) {
     return client.Call<Greeter, HelloRequest, HelloReply>("SayHello", host)
-        >> Then(Let([](auto& call) {
+        >> Then(Let([](ClientCall<HelloRequest, HelloReply>& call) {
              HelloRequest request;
              request.set_name("Emily");
              return call.Writer().WriteLast(request)

--- a/test/grpc/server-unavailable.cc
+++ b/test/grpc/server-unavailable.cc
@@ -30,7 +30,7 @@ TEST(ServerUnavailableTest, NonexistantServer) {
 
   auto call = [&]() {
     return client.Call<Greeter, HelloRequest, HelloReply>("SayHello")
-        >> Then(Let([](auto& call) {
+        >> Then(Let([](ClientCall<HelloRequest, HelloReply>& call) {
              return call.Finish();
            }));
   };

--- a/test/grpc/unary.cc
+++ b/test/grpc/unary.cc
@@ -45,7 +45,7 @@ void TestUnaryWithClient(
         >> Then(Let([](auto& call) {
              return call.Reader().Read()
                  >> Head() // Only get the first element.
-                 >> Then([](auto&& request) {
+                 >> Then([](HelloRequest&& request) {
                       HelloReply reply;
                       std::string prefix("Hello ");
                       reply.set_message(prefix + request.name());
@@ -69,7 +69,7 @@ void TestUnaryWithClient(
              request.set_name("emily");
              return call.Writer().WriteLast(request)
                  >> call.Reader().Read()
-                 >> Map([](auto&& response) {
+                 >> Map([](HelloReply&& response) {
                       EXPECT_EQ("Hello emily", response.message());
                     })
                  >> Loop()

--- a/test/http.cc
+++ b/test/http.cc
@@ -95,9 +95,9 @@ TEST_P(HttpTest, GetGet) {
 
   auto e = [&]() {
     return client.Get(server.uri())
-        >> Then(Let([&](auto& response1) {
+        >> Then(Let([&](Response& response1) {
              return client.Get(server.uri())
-                 >> Then([&](auto&& response2) {
+                 >> Then([&](Response&& response2) {
                       return std::tuple{response1, response2};
                     });
            }));

--- a/test/let.cc
+++ b/test/let.cc
@@ -20,7 +20,7 @@ TEST_F(LetTest, Let) {
 
   auto e = []() {
     return Just(Foo{41})
-        >> Then(Let([](auto& foo) {
+        >> Then(Let([](Foo& foo) {
              return Then([&]() {
                       foo.i += 1;
                     })

--- a/test/lock.cc
+++ b/test/lock.cc
@@ -33,7 +33,7 @@ TEST(LockTest, Succeed) {
                  thread.detach();
                })
         >> Acquire(&lock)
-        >> Then([](auto&& value) { return std::move(value); });
+        >> Then([](std::string&& value) { return std::move(value); });
   };
 
   auto e2 = [&]() {
@@ -46,7 +46,7 @@ TEST(LockTest, Succeed) {
                  thread.detach();
                })
         >> Acquire(&lock)
-        >> Then([](auto&& value) { return std::move(value); });
+        >> Then([](std::string&& value) { return std::move(value); });
   };
 
   auto e3 = [&]() {
@@ -87,7 +87,7 @@ TEST(LockTest, Fail) {
                  thread.detach();
                })
         >> Release(&lock)
-        >> Then([](auto&& value) { return std::move(value); });
+        >> Then([](std::string&& value) { return std::move(value); });
   };
 
   auto e2 = [&]() {
@@ -160,7 +160,7 @@ TEST(LockTest, Wait) {
         >> Acquire(&lock)
         >> Wait(&lock, [&](auto notify) {
              callback = std::move(notify);
-             return [waited = false](auto&& value) mutable {
+             return [waited = false](std::string&& value) mutable {
                if (!waited) {
                  waited = true;
                  return true;
@@ -274,7 +274,7 @@ TEST(LockTest, SynchronizedMap) {
              }))
           >> Reduce(
                  /* sum = */ 0,
-                 [](auto& sum) {
+                 [](int& sum) {
                    return Then([&](auto i) {
                      sum += i;
                      return true;
@@ -294,7 +294,7 @@ TEST(LockTest, ConditionVariable) {
     auto WaitFor(int id) {
       return Synchronized(Then([this, id]() {
         auto [iterator, inserted] = condition_variables_.emplace(id, &lock());
-        auto& condition_variable = iterator->second;
+        ConditionVariable& condition_variable = iterator->second;
         return condition_variable.Wait();
       }));
     }
@@ -307,7 +307,7 @@ TEST(LockTest, ConditionVariable) {
               return false;
             })
             .no([iterator]() {
-              auto& condition_variable = iterator->second;
+              ConditionVariable& condition_variable = iterator->second;
               condition_variable.Notify();
               return true;
             });
@@ -322,7 +322,7 @@ TEST(LockTest, ConditionVariable) {
               return false;
             })
             .no([iterator]() {
-              auto& condition_variable = iterator->second;
+              ConditionVariable& condition_variable = iterator->second;
               condition_variable.NotifyAll();
               return true;
             });

--- a/test/poll.cc
+++ b/test/poll.cc
@@ -46,7 +46,7 @@ TEST_F(PollTest, Succeed) {
                Poll(server, PollEvents::Readable)
                    >> Reduce(
                        /* data = */ std::string(),
-                       [&](auto& data) {
+                       [&](std::string& data) {
                          return Then([&](PollEvents events) {
                            EXPECT_EQ(
                                events & PollEvents::Readable,

--- a/test/protobuf/collect.cc
+++ b/test/protobuf/collect.cc
@@ -34,7 +34,7 @@ TEST(Collect, MoveValueIntoRepeatedPtrField) {
   auto s = [&]() {
     return Stream<std::string>()
                .context(false)
-               .next([&](auto& was_completed, auto& k) {
+               .next([&](bool& was_completed, auto& k) {
                  if (!was_completed) {
                    was_completed = true;
                    k.Emit(std::move(initial_str));

--- a/test/repeat.cc
+++ b/test/repeat.cc
@@ -21,23 +21,23 @@ TEST(RepeatTest, Succeed) {
   auto e = [](auto i) {
     return Eventual<int>()
         .context(i)
-        .start([](auto& i, auto& k) {
+        .start([](int& i, auto& k) {
           k.Start(std::move(i));
         });
   };
 
   auto r = [&]() {
     return Repeat([i = 0]() mutable { return i++; })
-        >> Until([](auto& i) {
+        >> Until([](int& i) {
              return i == 5;
            })
-        >> Map([&](auto&& i) {
+        >> Map([&](int&& i) {
              return e(i);
            })
         >> Reduce(
                /* sum = */ 0,
-               [](auto& sum) {
-                 return Then([&](auto&& i) {
+               [](int& sum) {
+                 return Then([&](int&& i) {
                    sum += i;
                    return true;
                  });
@@ -59,16 +59,16 @@ TEST(RepeatTest, Fail) {
 
   auto r = [&]() {
     return Repeat([i = 0]() mutable { return i++; })
-        >> Until([](auto& i) {
+        >> Until([](int& i) {
              return i == 5;
            })
-        >> Map([&](auto&& i) {
+        >> Map([&](int&& i) {
              return e(i);
            })
         >> Reduce(
                /* sum = */ 0,
-               [](auto& sum) {
-                 return Then([&](auto&& i) {
+               [](int& sum) {
+                 return Then([&](int&& i) {
                    sum += i;
                    return true;
                  });
@@ -99,16 +99,16 @@ TEST(RepeatTest, Interrupt) {
 
   auto r = [&]() {
     return Repeat([i = 0]() mutable { return i++; })
-        >> Until([](auto& i) {
+        >> Until([](int& i) {
              return i == 5;
            })
-        >> Map([&](auto&& i) {
+        >> Map([&](int&& i) {
              return e(i);
            })
         >> Reduce(
                /* sum = */ 0,
-               [](auto& sum) {
-                 return Then([&](auto&& i) {
+               [](int& sum) {
+                 return Then([&](int&& i) {
                    sum += i;
                    return true;
                  });
@@ -171,7 +171,7 @@ TEST(RepeatTest, MapAcquire) {
                  });
            })
         >> Acquire(&lock)
-        >> Map([](auto&& i) {
+        >> Map([](int&& i) {
              return i;
            })
         >> Release(&lock)

--- a/test/task.cc
+++ b/test/task.cc
@@ -383,8 +383,8 @@ TEST(Task, FromTo) {
   auto task = []() {
     return Task::From<int>::To<std::string>::With<int>(
         10,
-        [](auto x) {
-          return Then([x](auto&& value) {
+        [](int x) {
+          return Then([x](int&& value) {
             value += x;
             return std::to_string(value);
           });
@@ -620,7 +620,7 @@ TEST(Task, RefFunction) {
 
   auto e1 = [&]() {
     return e()
-        >> Then([](auto& v) {
+        >> Then([](int& v) {
              v += 100;
            });
   };
@@ -638,7 +638,7 @@ TEST(Task, RefSuccess) {
 
   auto e1 = [&]() {
     return e()
-        >> Then([](auto& v) {
+        >> Then([](int& v) {
              v += 100;
            });
   };

--- a/test/then.cc
+++ b/test/then.cc
@@ -15,10 +15,10 @@ using testing::StrEq;
 using testing::ThrowsMessage;
 
 TEST(ThenTest, Succeed) {
-  auto e = [](auto s) {
+  auto e = [](std::string s) {
     return Eventual<std::string>()
         .context(std::move(s))
-        .start([](auto& s, auto& k) {
+        .start([](std::string& s, auto& k) {
           k.Start(std::move(s));
         });
   };
@@ -26,7 +26,7 @@ TEST(ThenTest, Succeed) {
   auto c = [&]() {
     return Eventual<int>()
                .context(1)
-               .start([](auto& value, auto& k) {
+               .start([](int& value, auto& k) {
                  std::thread thread(
                      [&value, &k]() mutable {
                        k.Start(value);
@@ -34,7 +34,7 @@ TEST(ThenTest, Succeed) {
                  thread.detach();
                })
         >> Then([](int i) { return i + 1; })
-        >> Then([&](auto&& i) {
+        >> Then([&](int&& i) {
              return e("then");
            });
   };
@@ -59,10 +59,10 @@ TEST(ThenTest, SucceedVoid) {
 }
 
 TEST(ThenTest, Fail) {
-  auto e = [](auto s) {
+  auto e = [](std::string s) {
     return Eventual<std::string>()
         .context(s)
-        .start([](auto& s, auto& k) {
+        .start([](std::string& s, auto& k) {
           k.Start(std::move(s));
         });
   };
@@ -78,7 +78,7 @@ TEST(ThenTest, Fail) {
                  thread.detach();
                })
         >> Then([](int i) { return i + 1; })
-        >> Then([&](auto&& i) {
+        >> Then([&](int&& i) {
              return e("then");
            });
   };
@@ -111,7 +111,7 @@ TEST(ThenTest, Interrupt) {
                  k.Start(0);
                })
         >> Then([](int i) { return i + 1; })
-        >> Then([&](auto&& i) {
+        >> Then([&](int&& i) {
              return e("then");
            });
   };

--- a/test/transformer.cc
+++ b/test/transformer.cc
@@ -182,7 +182,7 @@ TEST(Transformer, PropagateStop) {
 
   auto transformer = []() {
     return Transformer::From<int>::To<std::string>([]() {
-      return Map(Let([](auto& i) {
+      return Map(Let([](int& i) {
         return Eventual<std::string>([](auto& k) {
           k.Stop();
         });
@@ -212,7 +212,7 @@ TEST(Transformer, PropagateFail) {
   auto transformer = []() {
     return Transformer::From<int>::To<std::string>::Raises<std::runtime_error>(
         []() {
-          return Map(Let([](auto& i) {
+          return Map(Let([](int& i) {
             return Eventual<std::string>()
                 .raises<std::runtime_error>()
                 .start([](auto& k) {


### PR DESCRIPTION
When using `auto` makes a type invisible to the reader, it makes code
harder for unfamiliar readers to understand. This is especially
impactful for readers looking at snippets of code to understand how to
use eventuals types, which happens a lot while most eventuals lack any
documentation.

Per https://google.github.io/styleguide/cppguide.html#Type_deduction :

> Use type deduction only if it makes the code clearer to readers who
> aren't familiar with the project, or if it makes the code safer. Do
> not use it merely to avoid the inconvenience of writing an explicit
> type.
