### PR TITLE
Fix 'DoAll()' so each eventual has own 'Scheduler::Context'

### DIFF
--- a/eventuals/callback.h
+++ b/eventuals/callback.h
@@ -4,6 +4,8 @@
 #include <type_traits> // For std::aligned_storage.
 #include <utility> // For std::move.
 
+#include "stout/borrowable.h"
+
 ////////////////////////////////////////////////////////////////////////
 
 namespace eventuals {
@@ -129,9 +131,16 @@ struct Callback<R(Args...)> final {
     F f_;
   };
 
-  // NOTE: we allow up to 2 * sizeof(void*) to accomodate storing a
+  // NOTE: helper function used only to get a type so we can determine
+  // the size necessary to accomodate storing a
   // 'stout::borrowed_callable'.
-  static constexpr std::size_t SIZE = (2 * sizeof(void*)) + sizeof(Base);
+  static auto BorrowedCallable() {
+    stout::Borrowable<int> borrowable;
+    return borrowable.Borrow([i = new int]() {});
+  }
+
+  static constexpr std::size_t SIZE =
+      sizeof(decltype(BorrowedCallable())) + sizeof(Base);
 
   std::aligned_storage_t<SIZE> storage_;
 

--- a/eventuals/head.h
+++ b/eventuals/head.h
@@ -61,7 +61,9 @@ struct _Head final {
     using ValueFrom = Arg;
 
     template <typename Arg, typename Errors>
-    using ErrorsFrom = Errors;
+    using ErrorsFrom = tuple_types_union_t<
+        std::tuple<std::runtime_error>,
+        Errors>;
 
     template <typename Arg, typename K>
     auto k(K k) && {

--- a/eventuals/iterate.h
+++ b/eventuals/iterate.h
@@ -45,7 +45,7 @@ template <typename Container>
 
   return Stream<T>()
       .context(Data{container, std::nullopt})
-      .begin([](Data& data, auto& k) {
+      .begin([](Data& data, auto& k, auto&&...) {
         data.begin = data.container.cbegin();
         k.Begin();
       })
@@ -76,7 +76,7 @@ template <typename Container>
 
   return Stream<T>()
       .context(Data{container, std::nullopt})
-      .begin([](Data& data, auto& k) {
+      .begin([](Data& data, auto& k, auto&&...) {
         data.begin = data.container.begin();
         k.Begin();
       })
@@ -109,7 +109,7 @@ template <typename Container>
 
   return Stream<T>()
       .context(Data{std::move(container), std::nullopt})
-      .begin([](Data& data, auto& k) {
+      .begin([](Data& data, auto& k, auto&&...) {
         data.begin = data.container.begin();
         k.Begin();
       })

--- a/eventuals/map.h
+++ b/eventuals/map.h
@@ -110,7 +110,9 @@ struct _Map final {
     using ValueFrom = typename E_::template ValueFrom<Arg>;
 
     template <typename Arg, typename Errors>
-    using ErrorsFrom = typename E_::template ErrorsFrom<Arg, Errors>;
+    using ErrorsFrom = tuple_types_union_t<
+        Errors,
+        typename E_::template ErrorsFrom<Arg, std::tuple<>>>;
 
     template <typename Arg, typename K>
     auto k(K k) && {

--- a/eventuals/reduce.h
+++ b/eventuals/reduce.h
@@ -120,7 +120,9 @@ struct _Reduce final {
             std::add_lvalue_reference_t<T_>>;
 
     template <typename Arg, typename Errors>
-    using ErrorsFrom = typename E_::template ErrorsFrom<Arg, Errors>;
+    using ErrorsFrom = tuple_types_union_t<
+        Errors,
+        typename E_::template ErrorsFrom<Arg, std::tuple<>>>;
 
     template <typename Arg, typename K>
     auto k(K k) && {

--- a/protoc-gen-eventuals/templates/eventuals.cc.j2
+++ b/protoc-gen-eventuals/templates/eventuals.cc.j2
@@ -5,6 +5,7 @@ set namespaces = package_name.split('.')
 
 #include "eventuals/concurrent.h"
 #include "eventuals/do-all.h"
+#include "eventuals/finally.h"
 #include "eventuals/grpc/server.h"
 #include "eventuals/just.h"
 #include "eventuals/let.h"
@@ -15,6 +16,7 @@ set namespaces = package_name.split('.')
 
 using eventuals::Concurrent;
 using eventuals::DoAll;
+using eventuals::Finally;
 using eventuals::Just;
 using eventuals::Let;
 using eventuals::Loop;
@@ -123,7 +125,25 @@ Task::Of<void> {{ service.name }}::TypeErasedService::Serve{{ method.name }}() {
 {%- endif %}
               }));{# Map #}
           }){# Concurrent #}
-          >> Loop();
+          >> Loop()
+          // TODO(benh): currently we need to have a 'Finally()'
+          // because we have a 'Task' that doesn't raise any errors
+          // but we probably would prefer to have the 'Finally()'
+          // on each served call so that a single failed call
+          // doesn't fail all of the calls.
+          >> Finally([&](auto&& expected) {
+               if (!expected.has_value()) {
+                 try {
+                   std::rethrow_exception(expected.error());
+                 } catch (std::exception& e) {
+                   LOG(WARNING) << "Failed to serve: " << e.what();
+                 } catch (...) {
+                   LOG(WARNING)
+                       << "Failed to serve (unexpected error that "
+                       << "does not extend from 'std::exception')";
+                 }
+               }
+            });
         };
 }
 {% endfor %}

--- a/test/stream.cc
+++ b/test/stream.cc
@@ -492,7 +492,7 @@ TEST(StreamTest, ThrowGeneralError) {
   static_assert(
       eventuals::tuple_types_unordered_equals_v<
           decltype(e())::ErrorsFrom<void, std::tuple<>>,
-          std::tuple<std::bad_alloc, std::exception>>);
+          std::tuple<std::runtime_error, std::bad_alloc, std::exception>>);
 
   EXPECT_THAT(
       [&]() { *e(); },


### PR DESCRIPTION
Also fixes a bug where the return value must be default constructible
by making the first item in the 'std::variant' be an 'Undefined'.