### PR TITLE
Introduce 'TestingCompletionThreadPool'

### DIFF
--- a/eventuals/grpc/BUILD.bazel
+++ b/eventuals/grpc/BUILD.bazel
@@ -4,6 +4,7 @@ load("//bazel:copts.bzl", "copts")
 cc_library(
     name = "grpc",
     srcs = [
+        "completion-thread-pool.cc",
         "server.cc",
     ],
     hdrs = [

--- a/eventuals/grpc/BUILD.bazel
+++ b/eventuals/grpc/BUILD.bazel
@@ -9,7 +9,7 @@ cc_library(
     hdrs = [
         "call-type.h",
         "client.h",
-        "completion-pool.h",
+        "completion-thread-pool.h",
         "logging.h",
         "server.h",
         "traits.h",

--- a/eventuals/grpc/client.h
+++ b/eventuals/grpc/client.h
@@ -2,7 +2,7 @@
 
 #include "eventuals/callback.h"
 #include "eventuals/eventual.h"
-#include "eventuals/grpc/completion-pool.h"
+#include "eventuals/grpc/completion-thread-pool.h"
 #include "eventuals/grpc/logging.h"
 #include "eventuals/grpc/traits.h"
 #include "eventuals/lazy.h"
@@ -301,13 +301,13 @@ class Client {
   explicit Client(
       const std::string& target,
       const std::shared_ptr<::grpc::ChannelCredentials>& credentials,
-      stout::borrowed_ref<CompletionPool> pool)
+      stout::borrowed_ref<CompletionThreadPool> pool)
     : channel_(::grpc::CreateChannel(target, credentials)),
       pool_(std::move(pool)) {}
 
   explicit Client(
       std::shared_ptr<::grpc::Channel> channel,
-      stout::borrowed_ref<CompletionPool> pool)
+      stout::borrowed_ref<CompletionThreadPool> pool)
     : channel_(std::move(channel)),
       pool_(std::move(pool)) {}
 
@@ -492,7 +492,7 @@ class Client {
 
  private:
   std::shared_ptr<::grpc::Channel> channel_;
-  stout::borrowed_ref<CompletionPool> pool_;
+  stout::borrowed_ref<CompletionThreadPool> pool_;
 };
 
 ////////////////////////////////////////////////////////////////////////

--- a/eventuals/grpc/client.h
+++ b/eventuals/grpc/client.h
@@ -301,13 +301,13 @@ class Client {
   explicit Client(
       const std::string& target,
       const std::shared_ptr<::grpc::ChannelCredentials>& credentials,
-      stout::borrowed_ref<ClientCompletionThreadPool> pool)
+      stout::borrowed_ref<CompletionThreadPool<::grpc::CompletionQueue>>&& pool)
     : channel_(::grpc::CreateChannel(target, credentials)),
       pool_(std::move(pool)) {}
 
   explicit Client(
       std::shared_ptr<::grpc::Channel> channel,
-      stout::borrowed_ref<ClientCompletionThreadPool> pool)
+      stout::borrowed_ref<CompletionThreadPool<::grpc::CompletionQueue>>&& pool)
     : channel_(std::move(channel)),
       pool_(std::move(pool)) {}
 
@@ -492,7 +492,7 @@ class Client {
 
  private:
   std::shared_ptr<::grpc::Channel> channel_;
-  stout::borrowed_ref<ClientCompletionThreadPool> pool_;
+  stout::borrowed_ref<CompletionThreadPool<::grpc::CompletionQueue>> pool_;
 };
 
 ////////////////////////////////////////////////////////////////////////

--- a/eventuals/grpc/client.h
+++ b/eventuals/grpc/client.h
@@ -185,7 +185,7 @@ class ClientCall {
       const std::string& path,
       const std::optional<std::string>& host,
       ::grpc::ClientContext* context,
-      stout::borrowed_ptr<::grpc::CompletionQueue>&& cq,
+      stout::borrowed_ref<::grpc::CompletionQueue>&& cq,
       ::grpc::TemplatedGenericStub<RequestType_, ResponseType_>&& stub,
       std::unique_ptr<
           ::grpc::ClientAsyncReaderWriter<
@@ -280,7 +280,7 @@ class ClientCall {
   // NOTE: we need to keep this around until after the call terminates
   // as it represents a "lease" on this completion queue that once
   // relinquished will allow another call to use this queue.
-  stout::borrowed_ptr<::grpc::CompletionQueue> cq_;
+  stout::borrowed_ref<::grpc::CompletionQueue> cq_;
 
   ::grpc::TemplatedGenericStub<RequestType_, ResponseType_> stub_;
 
@@ -301,13 +301,13 @@ class Client {
   explicit Client(
       const std::string& target,
       const std::shared_ptr<::grpc::ChannelCredentials>& credentials,
-      stout::borrowed_ref<CompletionThreadPool> pool)
+      stout::borrowed_ref<ClientCompletionThreadPool> pool)
     : channel_(::grpc::CreateChannel(target, credentials)),
       pool_(std::move(pool)) {}
 
   explicit Client(
       std::shared_ptr<::grpc::Channel> channel,
-      stout::borrowed_ref<CompletionThreadPool> pool)
+      stout::borrowed_ref<ClientCompletionThreadPool> pool)
     : channel_(std::move(channel)),
       pool_(std::move(pool)) {}
 
@@ -356,7 +356,7 @@ class Client {
       std::string name;
       std::string path;
       std::optional<std::string> host;
-      stout::borrowed_ptr<::grpc::CompletionQueue> cq;
+      stout::borrowed_ref<::grpc::CompletionQueue> cq;
       ::grpc::TemplatedGenericStub<RequestType, ResponseType> stub;
       std::unique_ptr<
           ::grpc::ClientAsyncReaderWriter<
@@ -492,7 +492,7 @@ class Client {
 
  private:
   std::shared_ptr<::grpc::Channel> channel_;
-  stout::borrowed_ref<CompletionThreadPool> pool_;
+  stout::borrowed_ref<ClientCompletionThreadPool> pool_;
 };
 
 ////////////////////////////////////////////////////////////////////////

--- a/eventuals/grpc/completion-thread-pool.cc
+++ b/eventuals/grpc/completion-thread-pool.cc
@@ -1,0 +1,135 @@
+#include "eventuals/grpc/completion-thread-pool.h"
+
+////////////////////////////////////////////////////////////////////////
+
+namespace eventuals {
+namespace grpc {
+
+////////////////////////////////////////////////////////////////////////
+
+TestingCompletionThreadPool::TestingCompletionThreadPool()
+  : server_proxy_(*this),
+    client_proxy_(client_cq_.Borrow()),
+    thread_(
+        [this]() {
+          do {
+            while (!pause_ && !shutdown_) {
+              RunUntilIdle();
+            }
+            if (!shutdown_) {
+              paused_ = true;
+              semaphore_.Wait();
+              paused_ = false;
+            }
+          } while (!shutdown_);
+        }) {}
+
+////////////////////////////////////////////////////////////////////////
+
+TestingCompletionThreadPool::~TestingCompletionThreadPool() {
+  shutdown_ = true;
+  semaphore_.Signal();
+  thread_.join();
+
+  void* tag = nullptr;
+  bool ok = false;
+
+  client_cq_->Shutdown();
+  while (client_cq_->Next(&tag, &ok)) {}
+
+  server_cq_->get()->Shutdown();
+  while (server_cq_->get()->Next(&tag, &ok)) {}
+}
+
+////////////////////////////////////////////////////////////////////////
+
+void TestingCompletionThreadPool::Pause() {
+  pause_ = true;
+  while (!paused_) {}
+}
+
+////////////////////////////////////////////////////////////////////////
+
+void TestingCompletionThreadPool::Resume() {
+  pause_ = false;
+  semaphore_.Signal();
+}
+
+////////////////////////////////////////////////////////////////////////
+
+stout::borrowed_ref<CompletionThreadPool<::grpc::CompletionQueue>>
+TestingCompletionThreadPool::ClientCompletionThreadPool() {
+  return client_proxy_.Borrow();
+}
+
+////////////////////////////////////////////////////////////////////////
+
+stout::borrowed_ref<CompletionThreadPool<::grpc::ServerCompletionQueue>>
+TestingCompletionThreadPool::ServerCompletionThreadPool() {
+  return server_proxy_.Borrow();
+}
+
+////////////////////////////////////////////////////////////////////////
+
+void TestingCompletionThreadPool::RunUntilCondition(
+    const std::function<bool()>& condition) {
+  CHECK(paused_) << "need to 'Pause()' the thread pool first!";
+  while (!condition()) {
+    RunUntilIdle();
+  }
+}
+
+////////////////////////////////////////////////////////////////////////
+
+void TestingCompletionThreadPool::RunUntilIdle() {
+  if (std::this_thread::get_id() != thread_.get_id()) {
+    CHECK(paused_) << "need to 'Pause()' the thread pool first!";
+  }
+  bool server_got_events = true;
+  bool client_got_events = true;
+  do {
+    if (server_cq_) {
+      server_got_events = RunUntilIdle(*(server_cq_->get()));
+    } else {
+      server_got_events = false;
+    }
+
+    client_got_events = RunUntilIdle(*client_cq_);
+  } while (client_got_events || server_got_events);
+}
+
+////////////////////////////////////////////////////////////////////////
+
+bool TestingCompletionThreadPool::RunUntilIdle(::grpc::CompletionQueue& cq) {
+  bool events = false;
+  bool timeout = false;
+  do {
+    void* tag = nullptr;
+    bool ok = false;
+
+    gpr_timespec deadline;
+    deadline.clock_type = GPR_TIMESPAN;
+    deadline.tv_sec = 0;
+    deadline.tv_nsec = 0;
+
+    switch (cq.AsyncNext(&tag, &ok, deadline)) {
+      case ::grpc::CompletionQueue::SHUTDOWN:
+        LOG(FATAL) << "Running the completion queue after shutting it down!";
+      case ::grpc::CompletionQueue::GOT_EVENT:
+        events = true;
+        (*static_cast<Callback<void(bool)>*>(tag))(ok);
+        break;
+      case ::grpc::CompletionQueue::TIMEOUT:
+        timeout = true;
+        break;
+    }
+  } while (!timeout);
+  return events;
+}
+
+////////////////////////////////////////////////////////////////////////
+
+} // namespace grpc
+} // namespace eventuals
+
+////////////////////////////////////////////////////////////////////////

--- a/eventuals/grpc/completion-thread-pool.h
+++ b/eventuals/grpc/completion-thread-pool.h
@@ -233,20 +233,7 @@ class TestingCompletionThreadPool {
   stout::borrowed_ref<CompletionThreadPool<::grpc::CompletionQueue>>
   ClientCompletionThreadPool();
 
-  // NOTE: taking a 'std::function' here instead of a 'Callback'
-  // because this is for testing where we don't care about dynamic
-  // memory allocation and it simplifies the tests.
-  void RunUntilCondition(const std::function<bool()>& condition);
-
-  template <typename T>
-  void RunUntil(const std::future<T>& future) {
-    return RunUntilCondition([&future]() {
-      auto status = future.wait_for(std::chrono::nanoseconds::zero());
-      return status == std::future_status::ready;
-    });
-  }
-
-  void RunUntilIdle();
+  bool RunUntilIdle();
 
  private:
   class ClientCompletionThreadPoolProxy

--- a/eventuals/grpc/completion-thread-pool.h
+++ b/eventuals/grpc/completion-thread-pool.h
@@ -14,9 +14,9 @@ namespace grpc {
 
 ////////////////////////////////////////////////////////////////////////
 
-class CompletionPool {
+class CompletionThreadPool {
  public:
-  CompletionPool() {
+  CompletionThreadPool() {
     unsigned int threads = std::thread::hardware_concurrency();
     threads_.reserve(threads);
     cqs_.reserve(threads);
@@ -33,7 +33,7 @@ class CompletionPool {
     }
   }
 
-  ~CompletionPool() {
+  ~CompletionThreadPool() {
     Shutdown();
     Wait();
   }

--- a/eventuals/grpc/completion-thread-pool.h
+++ b/eventuals/grpc/completion-thread-pool.h
@@ -1,9 +1,12 @@
 #pragma once
 
 #include <deque>
+#include <future>
+#include <optional>
 #include <thread>
 
 #include "eventuals/callback.h"
+#include "eventuals/semaphore.h"
 #include "grpcpp/completion_queue.h"
 #include "stout/borrowable.h"
 
@@ -19,6 +22,8 @@ class CompletionThreadPool {
  public:
   virtual ~CompletionThreadPool() = default;
 
+  virtual void AddCompletionQueue(std::unique_ptr<CompletionQueue>&& cq) = 0;
+
   virtual size_t NumberOfCompletionQueues() = 0;
 
   virtual stout::borrowed_ref<CompletionQueue> Schedule() = 0;
@@ -27,41 +32,33 @@ class CompletionThreadPool {
 ////////////////////////////////////////////////////////////////////////
 
 // TODO(benh): 'DynamicCompletionThreadPool' which takes both a
-// minimum and a maximum number of polling threads per completion
-// queue.
+// minimum and a maximum number of threads per completion queue and
+// adds or removes them (or puts some to sleep) when they are
+// unnecessary. This is unlikely to be useful for eventuals only
+// codebases but may be useful if there are some calls to code that
+// can not be called asynchronously and block.
 
 ////////////////////////////////////////////////////////////////////////
 
+// A completion thread pool with a static number of threads per
+// completion queue.
+//
+// NOTE: to be thread-safe you *MUST* have only one thread that calls
+// 'AddCompletionQueue()' and then you may have as many threads as you
+// want call 'Schedule()' and only one thread should call 'Shutdown()'
+// and 'Wait()' (or just let the destructor do that for you).
 template <typename CompletionQueue>
 class StaticCompletionThreadPool
   : public CompletionThreadPool<CompletionQueue> {
  public:
   StaticCompletionThreadPool(
       std::vector<std::unique_ptr<CompletionQueue>>&& cqs,
-      unsigned int number_of_polling_threads_per_completion_queue = 1) {
-    threads_.reserve(
-        cqs.size() * number_of_polling_threads_per_completion_queue);
-    for (std::unique_ptr<CompletionQueue>& cq : cqs) {
-      cqs_.emplace_back(std::move(cq));
-      for (size_t i = 0;
-           i < number_of_polling_threads_per_completion_queue;
-           ++i) {
-        threads_.emplace_back(
-            [cq = cqs_.back().get()]() {
-              void* tag = nullptr;
-              bool ok = false;
-              while (cq->Next(&tag, &ok)) {
-                (*static_cast<Callback<void(bool)>*>(tag))(ok);
-              }
-            });
-      }
-    }
-  }
+      unsigned int number_of_threads_per_completion_queue = 1);
 
   StaticCompletionThreadPool(
       unsigned int number_of_completion_queues =
           std::thread::hardware_concurrency(),
-      unsigned int number_of_polling_threads_per_completion_queue = 1);
+      unsigned int number_of_threads_per_completion_queue = 1);
 
   StaticCompletionThreadPool(StaticCompletionThreadPool&& that) = default;
 
@@ -97,11 +94,38 @@ class StaticCompletionThreadPool
     }
   }
 
+  void AddCompletionQueue(std::unique_ptr<CompletionQueue>&& cq) override {
+    CHECK(!scheduling_)
+        << "\n"
+        << "\n"
+        << "It is currently *NOT* safe to call 'AddCompletionQueue()' after\n"
+        << "starting to make calls to 'Schedule()'. You should add all of\n"
+        << "your completion queues first and then once you start calling\n"
+        << "'Schedule()' you should not add any more!\n"
+        << "\n";
+
+    cqs_.emplace_back(std::move(cq));
+    for (size_t i = 0;
+         i < number_of_threads_per_completion_queue_;
+         ++i) {
+      threads_.emplace_back(
+          [cq = cqs_.back().get()]() {
+            void* tag = nullptr;
+            bool ok = false;
+            while (cq->Next(&tag, &ok)) {
+              (*static_cast<Callback<void(bool)>*>(tag))(ok);
+            }
+          });
+    }
+  }
+
   size_t NumberOfCompletionQueues() override {
     return cqs_.size();
   }
 
   stout::borrowed_ref<CompletionQueue> Schedule() override {
+    scheduling_ = true;
+
     // TODO(benh): provide alternative "scheduling" algorithms in
     // addition to "least loaded", e.g., round-robin, random, but
     // careful not to break anyone that currently assumes the "least
@@ -122,10 +146,28 @@ class StaticCompletionThreadPool
  private:
   std::deque<stout::Borrowable<std::unique_ptr<CompletionQueue>>> cqs_;
 
+  size_t number_of_threads_per_completion_queue_ = 1;
+
   std::vector<std::thread> threads_;
 
+  bool scheduling_ = false;
   bool shutdown_ = false;
 };
+
+////////////////////////////////////////////////////////////////////////
+
+template <typename CompletionQueue>
+StaticCompletionThreadPool<CompletionQueue>::
+    StaticCompletionThreadPool(
+        std::vector<std::unique_ptr<CompletionQueue>>&& cqs,
+        unsigned int number_of_threads_per_completion_queue)
+  : number_of_threads_per_completion_queue_(
+      number_of_threads_per_completion_queue) {
+  threads_.reserve(cqs.size() * number_of_threads_per_completion_queue);
+  for (std::unique_ptr<CompletionQueue>& cq : cqs) {
+    AddCompletionQueue(std::move(cq));
+  }
+}
 
 ////////////////////////////////////////////////////////////////////////
 
@@ -133,7 +175,7 @@ template <>
 inline StaticCompletionThreadPool<::grpc::CompletionQueue>::
     StaticCompletionThreadPool(
         unsigned int number_of_completion_queues,
-        unsigned int number_of_polling_threads_per_completion_queue)
+        unsigned int number_of_threads_per_completion_queue)
   : StaticCompletionThreadPool(
       [&number_of_completion_queues]() {
         std::vector<std::unique_ptr<::grpc::CompletionQueue>> cqs;
@@ -142,7 +184,7 @@ inline StaticCompletionThreadPool<::grpc::CompletionQueue>::
         }
         return cqs;
       }(),
-      number_of_polling_threads_per_completion_queue) {}
+      number_of_threads_per_completion_queue) {}
 
 ////////////////////////////////////////////////////////////////////////
 
@@ -151,7 +193,7 @@ template <>
 StaticCompletionThreadPool<::grpc::ServerCompletionQueue>::
     StaticCompletionThreadPool(
         unsigned int number_of_completion_queues,
-        unsigned int number_of_polling_threads_per_completion_queue) = delete;
+        unsigned int number_of_threads_per_completion_queue) = delete;
 
 ////////////////////////////////////////////////////////////////////////
 
@@ -162,6 +204,131 @@ using ClientCompletionThreadPool =
 
 using ServerCompletionThreadPool =
     StaticCompletionThreadPool<::grpc::ServerCompletionQueue>;
+
+////////////////////////////////////////////////////////////////////////
+
+// Helper for writing deterministic tests that require specific
+// orderings to be true.
+//
+// This thread pool starts off with a single thread that is _running_,
+// just like an 'EventLoop' starts of with the 'Clock' _not_
+// paused. You need to 'Pause()' this thread pool before making any
+// gRPC calls if you don't want anything to happen until you call one
+// of the 'RunUntil()' functions.
+//
+// NOTE: you must call 'Resume()' _before_ your test finishes or else
+// you might deadlock with '~Server()'. If you explicitly call
+// 'Server::Shutdown()' then you must 'Resume()' before that call.
+class TestingCompletionThreadPool {
+ public:
+  TestingCompletionThreadPool();
+  ~TestingCompletionThreadPool();
+
+  void Pause();
+  void Resume();
+
+  stout::borrowed_ref<CompletionThreadPool<::grpc::ServerCompletionQueue>>
+  ServerCompletionThreadPool();
+
+  stout::borrowed_ref<CompletionThreadPool<::grpc::CompletionQueue>>
+  ClientCompletionThreadPool();
+
+  // NOTE: taking a 'std::function' here instead of a 'Callback'
+  // because this is for testing where we don't care about dynamic
+  // memory allocation and it simplifies the tests.
+  void RunUntilCondition(const std::function<bool()>& condition);
+
+  template <typename T>
+  void RunUntil(const std::future<T>& future) {
+    return RunUntilCondition([&future]() {
+      auto status = future.wait_for(std::chrono::nanoseconds::zero());
+      return status == std::future_status::ready;
+    });
+  }
+
+  void RunUntilIdle();
+
+ private:
+  class ClientCompletionThreadPoolProxy
+    : public CompletionThreadPool<::grpc::CompletionQueue> {
+   public:
+    ClientCompletionThreadPoolProxy(
+        stout::borrowed_ref<::grpc::CompletionQueue>&& cq)
+      : cq_(std::move(cq)) {}
+
+    void AddCompletionQueue(
+        std::unique_ptr<::grpc::CompletionQueue>&& cq) override {
+      LOG(FATAL)
+          << "You can not add completion "
+          << "queues to a 'TestingCompletionThreadPool'";
+    }
+
+    size_t NumberOfCompletionQueues() override {
+      return 1;
+    }
+
+    stout::borrowed_ref<::grpc::CompletionQueue> Schedule() override {
+      return cq_.reborrow();
+    }
+
+   private:
+    stout::borrowed_ref<::grpc::CompletionQueue> cq_;
+  };
+
+  class ServerCompletionThreadPoolProxy
+    : public CompletionThreadPool<::grpc::ServerCompletionQueue> {
+   public:
+    // NOTE: we "borrow" a reference to our outer class
+    // 'TestingCompletionThreadPool' but we don't bother using
+    // 'stout::borrowed_ref' because the outer class will always
+    // outlive the proxy.
+    ServerCompletionThreadPoolProxy(TestingCompletionThreadPool& pool)
+      : pool_(pool) {}
+
+    void AddCompletionQueue(
+        std::unique_ptr<::grpc::ServerCompletionQueue>&& cq) override {
+      CHECK(!pool_.server_cq_)
+          << "You shouldn't be setting the number of completion queues "
+          << "to more than 1 when you're using 'TestingCompletionThreadPool'";
+      pool_.server_cq_.emplace(std::move(cq));
+    }
+
+    size_t NumberOfCompletionQueues() override {
+      return 1;
+    }
+
+    stout::borrowed_ref<::grpc::ServerCompletionQueue> Schedule() override {
+      CHECK(pool_.server_cq_) << "You haven't added any completion queues yet!";
+      return pool_.server_cq_->Borrow();
+    }
+
+   private:
+    TestingCompletionThreadPool& pool_;
+  };
+
+  // Helper for running a single completion queue until idle.
+  bool RunUntilIdle(::grpc::CompletionQueue& cq);
+
+  // NOTE: server completion queue is optional because we can't
+  // construct one unless you build a server using 'ServerBuilder' and
+  // we might have a test that doesn't build a server!
+  std::optional<
+      stout::Borrowable<
+          std::unique_ptr<::grpc::ServerCompletionQueue>>>
+      server_cq_;
+
+  stout::Borrowable<::grpc::CompletionQueue> client_cq_;
+
+  // NOTE: invariant here that the server proxy is outlived by 'this'.
+  stout::Borrowable<ServerCompletionThreadPoolProxy> server_proxy_;
+  stout::Borrowable<ClientCompletionThreadPoolProxy> client_proxy_;
+
+  Semaphore semaphore_;
+  std::atomic<bool> pause_ = false;
+  std::atomic<bool> paused_ = false;
+  std::atomic<bool> shutdown_ = false;
+  std::thread thread_;
+};
 
 ////////////////////////////////////////////////////////////////////////
 

--- a/eventuals/grpc/server.cc
+++ b/eventuals/grpc/server.cc
@@ -42,9 +42,9 @@ auto Server::RequestCall(
             context->context(),
             context->stream(),
             // TODO(benh): use completion queue from
-            // CompletionPool for each call rather than the
-            // notification completion queue that we are using
-            // for server notifications?
+            // CompletionThreadPool for each call rather than the
+            // notification completion queue that we are using for
+            // server notifications?
             cq,
             cq,
             &callback);

--- a/eventuals/grpc/server.cc
+++ b/eventuals/grpc/server.cc
@@ -229,10 +229,17 @@ Server::~Server() {
 
 ////////////////////////////////////////////////////////////////////////
 
-void Server::Shutdown() {
+void Server::Shutdown(
+    const std::optional<
+        std::chrono::time_point<
+            std::chrono::system_clock>>& deadline) {
   // Server might have already been shutdown.
   if (server_) {
-    server_->Shutdown();
+    if (deadline.has_value()) {
+      server_->Shutdown(deadline.value());
+    } else {
+      server_->Shutdown();
+    }
   }
 
   // NOTE: we don't interrupt 'workers_' or 'serves_' as shutting down

--- a/eventuals/grpc/server.h
+++ b/eventuals/grpc/server.h
@@ -1,7 +1,9 @@
 #pragma once
 
 #include <cassert>
+#include <chrono>
 #include <deque>
+#include <optional>
 #include <string_view>
 #include <thread>
 #include <variant>
@@ -541,7 +543,10 @@ class Server : public Synchronizable {
  public:
   ~Server();
 
-  void Shutdown();
+  void Shutdown(
+      const std::optional<
+          std::chrono::time_point<
+              std::chrono::system_clock>>& deadline = std::nullopt);
 
   void Wait();
 

--- a/eventuals/promisify.h
+++ b/eventuals/promisify.h
@@ -81,7 +81,11 @@ auto operator*(E e) {
     k.Start();
 
     if (EventLoop::HasDefault()) {
-      EventLoop::Default().RunUntil(future);
+      // TODO(benh): return EventLoop::Default().Run(std::move(e));
+      while (future.wait_for(std::chrono::seconds::zero())
+             != std::future_status::ready) {
+        EventLoop::Default().RunUntilIdle();
+      }
     }
 
     return future.get();

--- a/test/event-loop-test.h
+++ b/test/event-loop-test.h
@@ -7,12 +7,33 @@ namespace eventuals::test {
 
 class EventLoopTest : public ::testing::Test {
  protected:
+  // NOTE: taking a 'std::function' here instead of a 'Callback'
+  // because this is for testing where we don't care about dynamic
+  // memory allocation and it simplifies the tests.
+  void RunUntil(const std::function<bool()>& condition) {
+    while (!condition()) {
+      EventLoop::Default().RunUntilIdle();
+    }
+  }
+
+  template <typename T>
+  void RunUntil(const std::future<T>& future) {
+    return RunUntil([&future]() {
+      auto status = future.wait_for(std::chrono::nanoseconds::zero());
+      return status == std::future_status::ready;
+    });
+  }
+
+  void RunUntilIdle() {
+    EventLoop::Default().RunUntilIdle();
+  }
+
   void SetUp() override {
-    eventuals::EventLoop::ConstructDefault();
+    EventLoop::ConstructDefault();
   }
 
   void TearDown() override {
-    eventuals::EventLoop::DestructDefault();
+    EventLoop::DestructDefault();
   }
 };
 

--- a/test/flat-map.cc
+++ b/test/flat-map.cc
@@ -213,7 +213,7 @@ TEST_F(FlatMapTest, Interrupt) {
 
   interrupt.Trigger();
 
-  EventLoop::Default().RunUntil(future);
+  RunUntil(future);
 
   auto result = future.get();
 

--- a/test/grpc/BUILD.bazel
+++ b/test/grpc/BUILD.bazel
@@ -106,3 +106,16 @@ cc_test(
         "@com_github_grpc_grpc//examples/protos:keyvaluestore",
     ],
 )
+
+cc_library(
+    name = "ordering-dependent-test",
+    hdrs = [
+        "ordering-dependent-test.h",
+    ],
+    visibility = ["//visibility:public"],
+    deps = [
+        "//eventuals",
+        "//eventuals/grpc",
+        "@com_github_google_googletest//:gtest",
+    ],
+)

--- a/test/grpc/cancelled-by-client.cc
+++ b/test/grpc/cancelled-by-client.cc
@@ -47,7 +47,7 @@ TEST(CancelledByClientTest, Cancelled) {
 
   k.Start();
 
-  Borrowable<CompletionPool> pool;
+  Borrowable<CompletionThreadPool> pool;
 
   Client client(
       "0.0.0.0:" + std::to_string(port),

--- a/test/grpc/cancelled-by-client.cc
+++ b/test/grpc/cancelled-by-client.cc
@@ -47,7 +47,7 @@ TEST(CancelledByClientTest, Cancelled) {
 
   k.Start();
 
-  Borrowable<CompletionThreadPool> pool;
+  Borrowable<ClientCompletionThreadPool> pool;
 
   Client client(
       "0.0.0.0:" + std::to_string(port),

--- a/test/grpc/cancelled-by-server.cc
+++ b/test/grpc/cancelled-by-server.cc
@@ -48,7 +48,7 @@ TEST(CancelledByServerTest, Cancelled) {
 
   k.Start();
 
-  Borrowable<CompletionPool> pool;
+  Borrowable<CompletionThreadPool> pool;
 
   Client client(
       "0.0.0.0:" + std::to_string(port),

--- a/test/grpc/cancelled-by-server.cc
+++ b/test/grpc/cancelled-by-server.cc
@@ -48,7 +48,7 @@ TEST(CancelledByServerTest, Cancelled) {
 
   k.Start();
 
-  Borrowable<CompletionThreadPool> pool;
+  Borrowable<ClientCompletionThreadPool> pool;
 
   Client client(
       "0.0.0.0:" + std::to_string(port),

--- a/test/grpc/deadline.cc
+++ b/test/grpc/deadline.cc
@@ -48,7 +48,7 @@ TEST(DeadlineTest, DeadlineExceeded) {
 
   k.Start();
 
-  Borrowable<CompletionPool> pool;
+  Borrowable<CompletionThreadPool> pool;
 
   Client client(
       "0.0.0.0:" + std::to_string(port),

--- a/test/grpc/deadline.cc
+++ b/test/grpc/deadline.cc
@@ -48,7 +48,7 @@ TEST(DeadlineTest, DeadlineExceeded) {
 
   k.Start();
 
-  Borrowable<CompletionThreadPool> pool;
+  Borrowable<ClientCompletionThreadPool> pool;
 
   Client client(
       "0.0.0.0:" + std::to_string(port),

--- a/test/grpc/death-client.cc
+++ b/test/grpc/death-client.cc
@@ -14,7 +14,7 @@ using helloworld::HelloRequest;
 using stout::Borrowable;
 
 void RunClient(const int port) {
-  Borrowable<CompletionPool> pool;
+  Borrowable<CompletionThreadPool> pool;
 
   Client client(
       "0.0.0.0:" + std::to_string(port),

--- a/test/grpc/death-client.cc
+++ b/test/grpc/death-client.cc
@@ -14,7 +14,7 @@ using helloworld::HelloRequest;
 using stout::Borrowable;
 
 void RunClient(const int port) {
-  Borrowable<CompletionThreadPool> pool;
+  Borrowable<ClientCompletionThreadPool> pool;
 
   Client client(
       "0.0.0.0:" + std::to_string(port),

--- a/test/grpc/greeter-server.cc
+++ b/test/grpc/greeter-server.cc
@@ -51,7 +51,7 @@ TEST(GreeterServerTest, SayHello) {
 
   ASSERT_TRUE(server);
 
-  Borrowable<CompletionThreadPool> pool;
+  Borrowable<ClientCompletionThreadPool> pool;
 
   Client client(
       "0.0.0.0:" + std::to_string(port),

--- a/test/grpc/greeter-server.cc
+++ b/test/grpc/greeter-server.cc
@@ -51,7 +51,7 @@ TEST(GreeterServerTest, SayHello) {
 
   ASSERT_TRUE(server);
 
-  Borrowable<CompletionPool> pool;
+  Borrowable<CompletionThreadPool> pool;
 
   Client client(
       "0.0.0.0:" + std::to_string(port),

--- a/test/grpc/multiple-hosts.cc
+++ b/test/grpc/multiple-hosts.cc
@@ -59,7 +59,7 @@ TEST(MultipleHostsTest, Success) {
 
   w.Start();
 
-  Borrowable<CompletionThreadPool> pool;
+  Borrowable<ClientCompletionThreadPool> pool;
 
   Client client(
       "0.0.0.0:" + std::to_string(port),

--- a/test/grpc/multiple-hosts.cc
+++ b/test/grpc/multiple-hosts.cc
@@ -59,7 +59,7 @@ TEST(MultipleHostsTest, Success) {
 
   w.Start();
 
-  Borrowable<CompletionPool> pool;
+  Borrowable<CompletionThreadPool> pool;
 
   Client client(
       "0.0.0.0:" + std::to_string(port),

--- a/test/grpc/ordering-dependent-test.h
+++ b/test/grpc/ordering-dependent-test.h
@@ -1,0 +1,112 @@
+#pragma once
+
+#include <chrono>
+#include <functional>
+#include <future>
+
+#include "eventuals/event-loop.h"
+#include "eventuals/grpc/completion-thread-pool.h"
+#include "gtest/gtest.h"
+
+namespace eventuals::grpc::test {
+
+// 'OrderingDependentTest' provides a testing fixture that let's you
+// write tests where you are about orderings between the event loop
+// and gRPC.
+//
+// NOTE: we're explicitly not inheriting from 'EventLoopTest' to get
+// things like their 'SetUp' and 'TearDown' because if functionality
+// gets added to that test it might get used but not account properly
+// for the gRPC thread pools as well.
+class OrderingDependentTest : public ::testing::Test {
+ protected:
+  // NOTE: taking a 'std::function' here instead of a 'Callback'
+  // because this is for testing where we don't care about dynamic
+  // memory allocation and it simplifies the tests.
+  void RunUntil(const std::function<bool()>& condition) {
+    while (!condition()) {
+      RunUntilIdle();
+    }
+  }
+
+  template <typename T>
+  void RunUntil(const std::future<T>& future) {
+    return RunUntil([&future]() {
+      auto status = future.wait_for(std::chrono::nanoseconds::zero());
+      return status == std::future_status::ready;
+    });
+  }
+
+  void RunUntilIdle() {
+    CHECK(Clock().Paused()) << "clock is not paused!";
+    CHECK(paused_thread_pools_) << "thread pools are not paused!";
+
+    // NOTE: to break the cycle of knowing when we're really idle we
+    // always run the event loop and then if running the pool(s) does
+    // not run anything then we know that the event loop is also idle.
+    bool possibly_added_more_work = false;
+    do {
+      possibly_added_more_work = false;
+      EventLoop::Default().RunUntilIdle();
+      for (stout::Borrowable<TestingCompletionThreadPool>& pool : pools_) {
+        if (pool->RunUntilIdle()) {
+          possibly_added_more_work = true;
+        }
+      }
+    } while (possibly_added_more_work);
+  }
+
+  void PauseClockAndThreadPools() {
+    CHECK(!Clock().Paused()) << "clock is already paused!";
+    Clock().Pause();
+    PauseThreadPools();
+  }
+
+  void ResumeClockAndThreadPools() {
+    CHECK(Clock().Paused()) << "clock is not paused!";
+    Clock().Resume();
+    ResumeThreadPools();
+  }
+
+  void PauseThreadPools() {
+    CHECK(!paused_thread_pools_) << "thread pools are already paused!";
+    paused_thread_pools_ = true;
+    for (stout::Borrowable<TestingCompletionThreadPool>& pool : pools_) {
+      pool->Pause();
+    }
+  }
+
+  void ResumeThreadPools() {
+    CHECK(paused_thread_pools_) << "thread pools are not paused!";
+    paused_thread_pools_ = false;
+    for (stout::Borrowable<TestingCompletionThreadPool>& pool : pools_) {
+      pool->Resume();
+    }
+  }
+
+  void SetUp() override {
+    EventLoop::ConstructDefault();
+  }
+
+  void TearDown() override {
+    CHECK(!Clock().Paused()) << "you forgot to resume the clock!";
+    CHECK(!paused_thread_pools_) << "you forgot to resume the thread pools!";
+    pools_.clear();
+    EventLoop::DestructDefault();
+  }
+
+  stout::borrowed_ref<TestingCompletionThreadPool>
+  CreateTestingCompletionThreadPool() {
+    auto pool = pools_.emplace_back().Borrow();
+    if (paused_thread_pools_) {
+      pool->Pause();
+    }
+    return pool;
+  }
+
+ private:
+  std::deque<stout::Borrowable<TestingCompletionThreadPool>> pools_;
+  bool paused_thread_pools_ = false;
+};
+
+} // namespace eventuals::grpc::test

--- a/test/grpc/server-death-test.cc
+++ b/test/grpc/server-death-test.cc
@@ -55,7 +55,7 @@ TEST(ServerDeathTest, ClientReceivesUnavailable) {
 
   int port = WaitForPort();
 
-  Borrowable<CompletionThreadPool> pool;
+  Borrowable<ClientCompletionThreadPool> pool;
 
   Client client(
       "0.0.0.0:" + std::to_string(port),

--- a/test/grpc/server-death-test.cc
+++ b/test/grpc/server-death-test.cc
@@ -55,7 +55,7 @@ TEST(ServerDeathTest, ClientReceivesUnavailable) {
 
   int port = WaitForPort();
 
-  Borrowable<CompletionPool> pool;
+  Borrowable<CompletionThreadPool> pool;
 
   Client client(
       "0.0.0.0:" + std::to_string(port),

--- a/test/grpc/server-unavailable.cc
+++ b/test/grpc/server-unavailable.cc
@@ -19,7 +19,7 @@ using testing::StrEq;
 using testing::ThrowsMessage;
 
 TEST(ServerUnavailableTest, NonexistantServer) {
-  Borrowable<CompletionPool> pool;
+  Borrowable<CompletionThreadPool> pool;
 
   // NOTE: we use 'getpid()' to create a _unique_ UNIX domain socket
   // path that should never have a server listening on for this test.

--- a/test/grpc/server-unavailable.cc
+++ b/test/grpc/server-unavailable.cc
@@ -19,7 +19,7 @@ using testing::StrEq;
 using testing::ThrowsMessage;
 
 TEST(ServerUnavailableTest, NonexistantServer) {
-  Borrowable<CompletionThreadPool> pool;
+  Borrowable<ClientCompletionThreadPool> pool;
 
   // NOTE: we use 'getpid()' to create a _unique_ UNIX domain socket
   // path that should never have a server listening on for this test.

--- a/test/grpc/streaming.cc
+++ b/test/grpc/streaming.cc
@@ -89,7 +89,7 @@ void test_client_behavior(Handler handler) {
 
   k.Start();
 
-  Borrowable<CompletionPool> pool;
+  Borrowable<CompletionThreadPool> pool;
 
   Client client(
       "0.0.0.0:" + std::to_string(port),

--- a/test/grpc/streaming.cc
+++ b/test/grpc/streaming.cc
@@ -89,7 +89,7 @@ void test_client_behavior(Handler handler) {
 
   k.Start();
 
-  Borrowable<CompletionThreadPool> pool;
+  Borrowable<ClientCompletionThreadPool> pool;
 
   Client client(
       "0.0.0.0:" + std::to_string(port),

--- a/test/grpc/unary.cc
+++ b/test/grpc/unary.cc
@@ -21,7 +21,7 @@ using stout::Borrowable;
 
 void TestUnaryWithClient(
     const std::function<Client(
-        stout::borrowed_ref<CompletionThreadPool>&&,
+        stout::borrowed_ref<ClientCompletionThreadPool>&&,
         int)>& client_factory) {
   ServerBuilder builder;
 
@@ -60,7 +60,7 @@ void TestUnaryWithClient(
 
   k.Start();
 
-  Borrowable<CompletionThreadPool> pool;
+  Borrowable<ClientCompletionThreadPool> pool;
 
   Client client = client_factory(pool.Borrow(), port);
 
@@ -95,7 +95,7 @@ void TestUnaryWithClient(
 
 TEST(UnaryTest, SuccessWithDefaultChannel) {
   TestUnaryWithClient(
-      [](stout::borrowed_ref<CompletionThreadPool>&& pool, const int port) {
+      [](stout::borrowed_ref<ClientCompletionThreadPool>&& pool, int port) {
         // Have the client construct its own channel.
         return Client(
             "0.0.0.0:" + std::to_string(port),
@@ -106,7 +106,7 @@ TEST(UnaryTest, SuccessWithDefaultChannel) {
 
 TEST(UnaryTest, SuccessWithCustomChannel) {
   TestUnaryWithClient(
-      [](stout::borrowed_ref<CompletionThreadPool>&& pool, const int port) {
+      [](stout::borrowed_ref<ClientCompletionThreadPool>&& pool, int port) {
         // Have the client use a channel that we've constructed ourselves.
         std::shared_ptr<::grpc::Channel> channel =
             ::grpc::CreateChannel(

--- a/test/grpc/unimplemented.cc
+++ b/test/grpc/unimplemented.cc
@@ -33,7 +33,7 @@ TEST(UnimplementedTest, ClientCallsUnimplementedServerMethod) {
 
   ASSERT_TRUE(server);
 
-  Borrowable<CompletionPool> pool;
+  Borrowable<CompletionThreadPool> pool;
 
   Client client(
       "0.0.0.0:" + std::to_string(port),

--- a/test/grpc/unimplemented.cc
+++ b/test/grpc/unimplemented.cc
@@ -33,7 +33,7 @@ TEST(UnimplementedTest, ClientCallsUnimplementedServerMethod) {
 
   ASSERT_TRUE(server);
 
-  Borrowable<CompletionThreadPool> pool;
+  Borrowable<ClientCompletionThreadPool> pool;
 
   Client client(
       "0.0.0.0:" + std::to_string(port),

--- a/test/http.cc
+++ b/test/http.cc
@@ -172,7 +172,7 @@ TEST_P(HttpTest, GetInterrupt) {
 
   interrupt.Trigger();
 
-  EventLoop::Default().RunUntil(future);
+  RunUntil(future);
 
   EXPECT_THROW(future.get(), eventuals::StoppedException);
 }
@@ -195,7 +195,7 @@ TEST_P(HttpTest, PostInterrupt) {
 
   interrupt.Trigger();
 
-  EventLoop::Default().RunUntil(future);
+  RunUntil(future);
 
   EXPECT_THROW(future.get(), eventuals::StoppedException);
 }
@@ -226,7 +226,7 @@ TEST_P(HttpTest, GetInterruptAfterStart) {
       },
       context);
 
-  EventLoop::Default().RunUntil(future);
+  RunUntil(future);
 
   EXPECT_THROW(future.get(), eventuals::StoppedException);
 }
@@ -260,7 +260,7 @@ TEST_P(HttpTest, PostInterruptAfterStart) {
       },
       context);
 
-  EventLoop::Default().RunUntil(future);
+  RunUntil(future);
 
   EXPECT_THROW(future.get(), eventuals::StoppedException);
 }

--- a/test/signal.cc
+++ b/test/signal.cc
@@ -55,7 +55,7 @@ TEST_F(SignalTest, SignalComposition) {
       },
       context);
 
-  EventLoop::Default().RunUntil(future);
+  RunUntil(future);
 
   EXPECT_EQ(future.get(), "quit");
 }
@@ -80,7 +80,7 @@ TEST_F(SignalTest, WaitForSignal) {
       },
       context);
 
-  EventLoop::Default().RunUntil(future);
+  RunUntil(future);
 
   EXPECT_EQ(future.get(), SIGQUIT);
 }
@@ -99,7 +99,7 @@ TEST_F(SignalTest, SignalInterrupt) {
 
   interrupt.Trigger();
 
-  EventLoop::Default().RunUntil(future);
+  RunUntil(future);
 
   EXPECT_THROW(future.get(), eventuals::StoppedException);
 }

--- a/test/timer.cc
+++ b/test/timer.cc
@@ -22,7 +22,7 @@ TEST_F(EventLoopTest, Timer) {
   k.Start();
 
   auto start = Clock().Now();
-  EventLoop::Default().RunUntil(future);
+  RunUntil(future);
   auto end = Clock().Now();
 
   EXPECT_LE(std::chrono::milliseconds(10), end - start);
@@ -45,7 +45,7 @@ TEST_F(EventLoopTest, PauseAndAdvanceClock) {
 
   Clock().Advance(std::chrono::seconds(5));
 
-  EventLoop::Default().RunUntil(future);
+  RunUntil(future);
 
   EXPECT_EQ(42, future.get());
 
@@ -76,7 +76,7 @@ TEST_F(EventLoopTest, AddTimerAfterAdvancingClock) {
 
   Clock().Advance(std::chrono::seconds(4)); // Timer 1 fired, timer 2 in 1000ms.
 
-  EventLoop::Default().RunUntil(future1); // Fire timer 1.
+  RunUntil(future1); // Fire timer 1.
 
   future1.get();
 
@@ -85,7 +85,7 @@ TEST_F(EventLoopTest, AddTimerAfterAdvancingClock) {
   Clock().Resume();
 
   auto start = Clock().Now();
-  EventLoop::Default().RunUntil(future2);
+  RunUntil(future2);
   auto end = Clock().Now();
 
   EXPECT_LE(std::chrono::milliseconds(10), end - start);
@@ -111,7 +111,7 @@ TEST_F(EventLoopTest, InterruptTimer) {
     interrupt.Trigger();
   });
 
-  EventLoop::Default().RunUntil(future);
+  RunUntil(future);
 
   EXPECT_THROW(future.get(), eventuals::StoppedException);
 
@@ -136,13 +136,15 @@ TEST_F(EventLoopTest, PauseClockInterruptTimer) {
 
   interrupt.Trigger();
 
-  EventLoop::Default().RunUntil(future);
+  RunUntil(future);
 
   EXPECT_THROW(future.get(), eventuals::StoppedException);
 
   // Advance the clock so that we relinquish the borrow on the timer
   // and it can be destructed.
   Clock().Advance(std::chrono::seconds(100));
+
+  RunUntilIdle();
 
   Clock().Resume();
 }
@@ -159,7 +161,7 @@ TEST_F(EventLoopTest, TimerAfterTimer) {
   k.Start();
 
   auto start = Clock().Now();
-  EventLoop::Default().RunUntil(future);
+  RunUntil(future);
   auto end = Clock().Now();
 
   EXPECT_LE(std::chrono::milliseconds(10), end - start);
@@ -180,7 +182,7 @@ TEST_F(EventLoopTest, MapTimer) {
   k.Start();
 
   auto start = Clock().Now();
-  EventLoop::Default().RunUntil(future);
+  RunUntil(future);
   auto end = Clock().Now();
 
   EXPECT_LE(std::chrono::milliseconds(10), end - start);


### PR DESCRIPTION
NOTE: this PR has multiple smaller commits to make it easier to see the progression of changes.

Often when writing tests with gRPC you want to deterministically ensure some ordering of events to test a particular code path. You can do so by using a 'TestingCompletionThreadPool' which only has a single thread that can be paused so as to ensure that no computation takes place until a particular time or you can wait on it until there is no more work to be done.