### PR TITLE
Introduce 'EventLoop::RunOnce()' and refactor 'operator*' to use

### DIFF
--- a/eventuals/interrupt.h
+++ b/eventuals/interrupt.h
@@ -44,7 +44,12 @@ class Interrupt final {
 
     void Invoke() {
       CHECK(callback_);
-      callback_();
+      // Need to move 'callback_' so that it will be destructed from
+      // the stack after we've invoked it in case invoking it causes
+      // some destructors to run and the callback has any borrows that
+      // need to get relinquished.
+      Callback<void()> callback = std::move(callback_);
+      callback();
     }
 
     Interrupt* interrupt_ = nullptr;

--- a/eventuals/static-thread-pool.h
+++ b/eventuals/static-thread-pool.h
@@ -165,6 +165,10 @@ struct _StaticThreadPoolSchedule final {
         engine_(device_()),
         k_(std::move(that.k_)) {}
 
+    ~Continuation() override {
+      this->WaitUntilBorrowsEquals(0);
+    }
+
     // Helper to avoid casting default 'Scheduler*' to 'StaticThreadPool*'
     // each time.
     auto* pool() {


### PR DESCRIPTION
This commit also introduces a 'Run()' function which 'operator*' now
calls instead (since 'operator*' is just syntactic sugar).