### PR TITLE
Thread implementation

### DIFF
--- a/test/BUILD.bazel
+++ b/test/BUILD.bazel
@@ -71,6 +71,7 @@ cc_test(
         "notification.cc",
         "on-begin.cc",
         "on-ended.cc",
+        "os.cc",
         "pipe.cc",
         "poll.cc",
         "range.cc",

--- a/test/os.cc
+++ b/test/os.cc
@@ -1,0 +1,85 @@
+#include "eventuals/os.h"
+
+#include <memory>
+
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+
+namespace eventuals::test {
+namespace {
+
+#ifndef _WIN32
+
+using eventuals::os::Thread;
+using testing::MockFunction;
+
+void foo() {
+  // Do nothing.
+}
+
+TEST(Thread, NotJoinable) {
+  Thread t;
+  EXPECT_FALSE(t.is_joinable());
+}
+
+TEST(Thread, Joinable) {
+  Thread t{&foo, "thread_name"};
+  EXPECT_TRUE(t.is_joinable());
+  t.join();
+  EXPECT_FALSE(t.is_joinable());
+}
+
+TEST(Thread, SetStackSize) {
+  Thread t{
+      []() {
+        EXPECT_EQ(os::GetStackInfo().size, Bytes(16'777'216));
+      },
+      "thread_name",
+      Bytes(16'777'216)};
+  EXPECT_TRUE(t.is_joinable());
+  t.join();
+  EXPECT_FALSE(t.is_joinable());
+}
+
+TEST(Thread, LambdaThatCapturesEverything) {
+  MockFunction<void()> start;
+
+  EXPECT_CALL(start, Call())
+      .Times(1);
+
+  Thread t{[&]() {
+             start.Call();
+           },
+           "thread_name"};
+
+  t.join();
+}
+
+TEST(Thread, LambdaThatCapturesNothing) {
+  Thread t{[]() {}, "thread_name"};
+  t.detach();
+}
+
+TEST(Thread, FunctionPointer) {
+  Thread t1{&foo, "thread_name1"};
+  Thread t2{foo, "thread_name2"};
+
+  t1.join();
+  t2.join();
+}
+
+TEST(Thread, Moveable) {
+  auto done = std::make_unique<bool>(true);
+
+  Thread t{[done = std::move(done)]() {
+             EXPECT_TRUE(*done);
+           },
+           "thread_name"};
+
+  t.join();
+}
+
+#endif
+
+} // namespace
+} // namespace eventuals::test


### PR DESCRIPTION
This PR implements 'Thread' class which has the possibility
to run the task in another thread as well as setting stack
size with specific value. For now this stuff works only on
`Linux` and `macOS`. For `Windows` the implementation might
be added in the future.