### PR TITLE
Remove the Windows build+test

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -43,14 +43,6 @@ jobs:
             bazel-command: "dazel"
             bazel-config: "--config=asan"
             output-user_root: ""
-          - os: windows-2019
-            sudo-command: "" # The Windows runner already runs as root.
-            # Explicitly not using `dazel` here as we don't want to
-            # build/test on Linux but on Windows!
-            bazel-command: "bazelisk"
-            bazel-config: ""
-            # Fixes issue #248.
-            output-user_root: "--output_user_root=C:/bzl"
       # Don't fail all workflows if one fails as we're still getting
       # to a stable build right now and when one fails it doesn't mean
       # they all will fail.


### PR DESCRIPTION
The Windows build is permanently broken and we have no immediate plans
to fix it. Remove it as a check for now, so that commits and PRs don't
spuriously show themselves as broken in GitHub's UI, and also to not
waste compute resources running a broken test.