### PR TITLE
Fix brew installation for ubuntu on workflow

### DIFF
--- a/.github/workflows/update-eventuals-tutorial.yml
+++ b/.github/workflows/update-eventuals-tutorial.yml
@@ -15,8 +15,8 @@ jobs:
   Update-Eventuals:
     runs-on: ubuntu-latest
     steps:
-      - name: Install buildifier for .bzl files
-        run: brew install buildifier
+      - name: Install buildifier for .bzl files (ubuntu)
+        run: /home/linuxbrew/.linuxbrew/bin/brew install buildifier
         shell: bash
 
       - uses: actions/checkout@v3


### PR DESCRIPTION
Our workflow fails on brew install on ubuntu.

https://github.com/3rdparty/eventuals/actions/runs/4793249892/jobs/8525533880
`/home/runner/work/_temp/f1046819-d924-4620-aca9-f6872b5e2677.sh: line 1: brew: command not found`

At the same time, we are using ubuntu brew in some other places using another signature.
This PR should fix the workflow brew error.