### PR TITLE
Remove a bunch of annoying clang-tidy checks

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -15,3 +15,6 @@ Checks: >
     modernize-*,
     performance-*,
     readability-*,
+    -modernize-use-trailing-return-type,
+    -readability-function-cognitive-complexity,
+    -readability-identifier-length,


### PR DESCRIPTION
Removes the following very annoying checks:

1. modernize-use-trailing-return-type - this check constantly notifies about an option to use smth like this:
```
auto add_two_values(int a, int b) -> int
```
Useless and is not used in eventuals codebase.

2.  readability-function-cognitive-complexity - eventuals by their nature have extremely complex codebase, some of the functions have a cognitive complexity of 300+, this check acts more like a noise at this point.

3. readability-identifier-length - eventuals use one-letter-variables extensively across the codebase, no need for this check today.