### PR TITLE
Minor fixes

### DIFF
--- a/eventuals/expected.h
+++ b/eventuals/expected.h
@@ -171,12 +171,12 @@ class expected : public tl::expected<Value_, Error_> {
                 Errors>>(std::move(k));
   }
 
-  using tl::expected<Value_, Error_>::expected;
-
   template <typename Downstream>
   static constexpr bool CanCompose = Downstream::ExpectsValue;
 
   using Expects = SingleValue;
+
+  using tl::expected<Value_, Error_>::expected;
 
   // Need explicit constructors for 'tl::expected', inherited
   // constructors are not sufficient.
@@ -185,6 +185,8 @@ class expected : public tl::expected<Value_, Error_> {
 
   expected(tl::expected<Value_, Error_>&& that)
     : tl::expected<Value_, Error_>::expected(std::move(that)) {}
+
+  using tl::expected<Value_, Error_>::operator*;
 };
 
 template <typename E>

--- a/eventuals/os.h
+++ b/eventuals/os.h
@@ -263,14 +263,11 @@ class Thread {
                  try {
                    data->callable();
                  } catch (const std::exception& e) {
-                   LOG(WARNING) << "Caught exception while running thread '"
-                                << data->thread_name
-                                << "': " << e.what();
+                   LOG(FATAL) << "Caught exception while running thread '"
+                              << data->thread_name << "': " << e.what();
                  } catch (...) {
-                   LOG(WARNING) << "Caught unknown exception while "
-                                   "running thread '"
-                                << data->thread_name
-                                << "'";
+                   LOG(FATAL) << "Caught unknown exception while running"
+                              << "thread '" << data->thread_name << "'";
                  }
                  delete data;
                  return nullptr;


### PR DESCRIPTION
* Add explicit using for operator* to `eventuals::expected`.

* Make some LOG(WARNING) be LOG(FATAL) so we don't hang forever when there are irrecoverable failures.