### PR TITLE
Disable build+test checks until they've been fixed

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -26,6 +26,9 @@ on:
 
 jobs:
   build-and-test:
+    # Remove the following when https://github.com/3rdparty/eventuals/issues/608
+    # has been fixed.
+    if: false
     name: Build and Test
     runs-on: ${{ matrix.runner }}
     strategy:


### PR DESCRIPTION
Due to https://github.com/3rdparty/eventuals/issues/608 the build/test checks are currently broken and actively harmful to our ability to merge PRs. This commit disables them until they've been fixed.