### PR TITLE
Update boringssl with lib_curl

### DIFF
--- a/bazel/repos.bzl
+++ b/bazel/repos.bzl
@@ -65,8 +65,8 @@ def repos(repo_mapping = {}):
         git_repository,
         name = "com_github_3rdparty_bazel_rules_curl",
         remote = "https://github.com/3rdparty/bazel-rules-curl",
-        commit = "5748da4b2594fab9410db9b5e6619b47cb5688e0",
-        shallow_since = "1651700487 +0300",
+        commit = "675ba89613943c2880ec58fb04dcac9b333ae5bf",
+        shallow_since = "1706221096 +0100",
         repo_mapping = repo_mapping,
     )
 

--- a/eventuals/rsa.h
+++ b/eventuals/rsa.h
@@ -31,7 +31,7 @@ class Key final {
 
   Key(std::unique_ptr<EVP_PKEY, decltype(&EVP_PKEY_free)> key)
     : key_(std::move(key)) {
-    CHECK_EQ(CHECK_NOTNULL(key_.get())->type, EVP_PKEY_RSA);
+    CHECK_EQ(EVP_PKEY_id(CHECK_NOTNULL(key_.get())), EVP_PKEY_RSA);
   }
 
   Key(const Key& that)
@@ -84,7 +84,7 @@ class Key final {
     // https://www.openssl.org/docs/manmaster/man3/EVP_PKEY_fromdata.html
 
     // Get the underlying RSA key.
-    CHECK_EQ(CHECK_NOTNULL(from.key_.get())->type, EVP_PKEY_RSA);
+    CHECK_EQ(EVP_PKEY_id(CHECK_NOTNULL(from.key_.get())), EVP_PKEY_RSA);
     RSA* rsa = EVP_PKEY_get1_RSA(from.key_.get());
 
     EVP_PKEY* to = EVP_PKEY_new();


### PR DESCRIPTION
Should go after that https://github.com/3rdparty/bazel-rules-curl/pull/18

Tested on the host MacOS arm64 machine.